### PR TITLE
Improve media preloading and gallery responsiveness

### DIFF
--- a/src/hooks/useAssetPreloader.js
+++ b/src/hooks/useAssetPreloader.js
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+
+/**
+ * Preload important assets so that subsequent navigations feel instant.
+ * Supports image and video sources. Videos are preloaded with a detached element
+ * to avoid layout shifts while still warming the cache.
+ */
+const useAssetPreloader = (assets = []) => {
+  useEffect(() => {
+    if (!assets.length) return undefined;
+
+    const preloadImage = (src) => {
+      const img = new Image();
+      img.decoding = 'async';
+      img.loading = 'eager';
+      img.src = src;
+    };
+
+    const preloadVideo = (src) => {
+      const video = document.createElement('video');
+      video.preload = 'auto';
+      video.src = src;
+      video.load();
+    };
+
+    const preloader = () => {
+      assets.forEach(({ src, type }) => {
+        if (!src) return;
+
+        if (type === 'video') {
+          preloadVideo(src);
+          return;
+        }
+
+        preloadImage(src);
+      });
+    };
+
+    if ('requestIdleCallback' in window) {
+      const id = window.requestIdleCallback(preloader, { timeout: 3000 });
+      return () => window.cancelIdleCallback(id);
+    }
+
+    const timeoutId = window.setTimeout(preloader, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [assets]);
+};
+
+export default useAssetPreloader;

--- a/src/pages/Gallery/GalleryPage.css
+++ b/src/pages/Gallery/GalleryPage.css
@@ -119,9 +119,10 @@ body {
 
 /* Section container styles */
 .section-container {
-  padding: 1.4rem;
-  width: 80%;
-  height: 95%;
+  padding: clamp(1rem, 2vw, 2rem);
+  width: 85%;
+  max-width: 1400px;
+  min-height: 60vh;
   margin: 0 auto;
   background-color: #ece9e8;
   background-image: radial-gradient(#08090a 0.85px, transparent 0.85px), radial-gradient(#08090a 0.85px, #ece9e8 0.85px);
@@ -131,7 +132,7 @@ body {
   margin-bottom: 2rem;
   text-align: center;
   /* height: 100vh; */
-  overflow-y: scroll;
+  overflow-y: visible;
 }
 
 .section-container h2 {
@@ -156,6 +157,11 @@ body {
 }
 
 @media (max-width: 768px) {
+  .section-container {
+    width: 92%;
+    padding: 1rem;
+  }
+
   .section-container h2 {
     font-size: 1.8rem;
   }
@@ -314,13 +320,41 @@ body {
 .image-container {
   position: relative;
   width: 100%;
-  height: auto;
+  min-height: 160px;
+  background: linear-gradient(135deg, #f4f2f1 0%, #ffffff 100%);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .image-container img {
   width: 100%;
   height: auto;
   transition: opacity 0.3s ease;
+}
+
+.loader {
+  width: 48px;
+  height: 48px;
+  border: 5px solid rgba(8, 9, 10, 0.08);
+  border-top-color: #08090a;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.image-fallback {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  color: #8a3d3d;
+  font-weight: 600;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Hero section styles */

--- a/src/pages/Gallery/GalleryPage.jsx
+++ b/src/pages/Gallery/GalleryPage.jsx
@@ -34,18 +34,51 @@ const GalleryPage = ({ match, history }) => {  // Get history from props using w
   const { docs } = useFirestore('images');
   const [loading, setLoading] = useState({});
   const [selectedSection, setSelectedSection] = useState(section || '');
-
-  const allSectionsLoaded = useRef(false);
-
-  useEffect(() => {
-    allSectionsLoaded.current = true;
-  }, []);
+  const prefetchedImages = useRef(new Set());
 
   useEffect(() => {
     if (section) {
       setSelectedSection(section);  // Automatically set the section based on the URL parameter
     }
   }, [section]);
+
+  useEffect(() => {
+    if (!docs.length) return;
+
+    setLoading((prev) => {
+      const updated = { ...prev };
+      let hasChange = false;
+
+      docs.forEach((doc) => {
+        if (updated[doc.id] === undefined) {
+          updated[doc.id] = true;
+          hasChange = true;
+        }
+      });
+
+      return hasChange ? updated : prev;
+    });
+
+    const preloadImages = () => {
+      const preloadTargets = docs.slice(0, 24).filter((doc) => !prefetchedImages.current.has(doc.url));
+
+      preloadTargets.forEach((doc) => {
+        const image = new Image();
+        image.decoding = 'async';
+        image.loading = 'eager';
+        image.src = doc.url;
+        prefetchedImages.current.add(doc.url);
+      });
+    };
+
+    if ('requestIdleCallback' in window) {
+      const idleId = window.requestIdleCallback(preloadImages, { timeout: 2000 });
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = window.setTimeout(preloadImages, 150);
+    return () => window.clearTimeout(timeoutId);
+  }, [docs]);
 
   const handleImageLoad = useCallback((id) => {
     setLoading((prev) => ({ ...prev, [id]: false }));
@@ -152,7 +185,7 @@ const Section = ({ index, section, filterDocs, docs, setSelectedImg, handleImage
       ) : (
         <ResponsiveMasonry columnsCountBreakPoints={{ 350: 2, 750: 4, 900: 6 }}>
           <Masonry gutter="10px">
-            {filterDocs(section.header).map((doc) => (
+            {filterDocs(section.header).map((doc, docIndex) => (
               <motion.div
                 className="image-box animate__animated animate__zoomInUp"
                 key={doc.id}
@@ -170,15 +203,20 @@ const Section = ({ index, section, filterDocs, docs, setSelectedImg, handleImage
                 transition={{ duration: 0.5 }}
               >
                 <div className="image-container">
-                  {loading[doc.id] !== false && <div className="loader"></div>}
+                  {loading[doc.id] === true && <div className="loader"></div>}
                   <img
                     ref={(el) => (imgRefs.current[doc.id] = el)}  // Assign ref for each image
                     data-src={doc.url}  // Lazy load using data-src
                     alt={`Gallery Image ${doc.title || 'No title'}`}
                     onLoad={() => handleImageLoad(doc.id)}
                     onError={() => handleImageError(doc.id)}
-                    style={{ display: loading[doc.id] ? 'none' : 'block' }}
+                    loading="lazy"
+                    decoding="async"
+                    fetchpriority={docIndex < 6 ? 'high' : 'low'}
+                    sizes="(max-width: 900px) 33vw, (max-width: 1200px) 20vw, 15vw"
+                    style={{ display: loading[doc.id] === false ? 'block' : 'none' }}
                   />
+                  {loading[doc.id] === 'error' && <p className="image-fallback">Image failed to load</p>}
                 </div>
                 <div className="image-info">
                   <h4>{doc.title}</h4>

--- a/src/pages/Intro/Intro.jsx
+++ b/src/pages/Intro/Intro.jsx
@@ -360,11 +360,13 @@ const Intro = () => {
           animate={{ opacity: 1 }}
           transition={{ duration: 2, delay: 1 }}
         >
-          <img 
-            className="animate__animated animate__fadeIn animate__delay-2s pic" 
-            src={Me} 
-            alt="Mark Yu" 
-            loading="lazy" 
+          <img
+            className="animate__animated animate__fadeIn animate__delay-2s pic"
+            src={Me}
+            alt="Mark Yu"
+            loading="eager"
+            decoding="async"
+            fetchpriority="high"
             width="500"
             height="500"
           />

--- a/src/pages/Main/Main.jsx
+++ b/src/pages/Main/Main.jsx
@@ -11,8 +11,10 @@ import Loading from '../../components/Loading';
 import Greeting from '../../components/Greeting';
 import { mediaQueries } from '../../theme/Themes';
 import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import useAssetPreloader from '../../hooks/useAssetPreloader';
 import videoBg from '../../assets/Images/videobg.webm';
 import videoBg2 from '../../assets/Images/videobg2.webm';
+import mePortrait from '../../assets/Images/me-pic.jpg';
 
 const SocialIcons = lazy(() => import('../../components/SocialIcons'));
 const LogoComponent = lazy(() => import('../../components/LogoComponent'));
@@ -180,6 +182,17 @@ const Main = () => {
   const [isMobile, setIsMobile] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
 
+  const assetPreloadList = useMemo(
+    () => [
+      { type: 'video', src: videoBg },
+      { type: 'video', src: videoBg2 },
+      { type: 'image', src: mePortrait },
+    ],
+    []
+  );
+
+  useAssetPreloader(assetPreloadList);
+
   const handleClick = useCallback(() => {
     setClick((prevClick) => !prevClick);
   }, []);
@@ -211,6 +224,9 @@ const Main = () => {
         />
         <meta name="author" content="Mark Yu" />
         <meta name="keywords" content="Mark Yu, Zhenxiao Yu, Software Engineer, Frontend Development, Game Design" />
+        <link rel="preload" href={videoBg} as="video" type="video/webm" />
+        <link rel="preload" href={videoBg2} as="video" type="video/webm" />
+        <link rel="preload" href={mePortrait} as="image" fetchpriority="high" />
       </Helmet>
       <Suspense fallback={<Loading />}>
         <MainContainer
@@ -229,9 +245,9 @@ const Main = () => {
               loop
               playsInline
               muted
-              preload="metadata"
+              preload="auto"
+              poster={mePortrait}
               className="video-background"
-              loading="lazy"
               aria-hidden="true"
             />
           ) : (
@@ -241,10 +257,9 @@ const Main = () => {
               loop
               playsInline
               muted
-              preload="metadata"
+              preload="auto"
               playbackRate={0.5}
               className="video-background"
-              loading="lazy"
               aria-hidden="true"
             />
           )}


### PR DESCRIPTION
## Summary
- preload hero media assets for smoother initial landing experience
- add reusable asset preloader and gallery-side warming of image caches with graceful fallbacks
- refresh gallery layout styles and loaders to keep the page responsive while images resolve

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695883ee449483339ef403b8cd637ce8)