### PR TITLE
Add infinite gallery scrolling and refine background video

### DIFF
--- a/src/pages/Gallery/GalleryPage.css
+++ b/src/pages/Gallery/GalleryPage.css
@@ -335,6 +335,17 @@ body {
   transition: opacity 0.3s ease;
 }
 
+.gallery-image {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease, visibility 0.35s ease;
+}
+
+.gallery-image.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
 .loader {
   width: 48px;
   height: 48px;
@@ -349,6 +360,11 @@ body {
   font-size: 0.9rem;
   color: #8a3d3d;
   font-weight: 600;
+}
+
+.load-more-trigger {
+  width: 100%;
+  height: 1px;
 }
 
 @keyframes spin {

--- a/src/pages/Main/Main.css
+++ b/src/pages/Main/Main.css
@@ -8,6 +8,8 @@
   object-fit: cover;
   z-index: 0;
   user-select: none;
+  opacity: 0;
+  transition: opacity 0.6s ease;
 }
 
 .video-placeholder {
@@ -15,4 +17,12 @@
     radial-gradient(circle at 75% 75%, rgba(8, 9, 10, 0.3), transparent 40%),
     linear-gradient(135deg, rgb(236, 233, 232), rgb(200, 205, 210));
   filter: saturate(0.8);
+}
+
+.video-background.is-visible {
+  opacity: 1;
+}
+
+.video-placeholder {
+  opacity: 1;
 }

--- a/src/pages/Main/Main.jsx
+++ b/src/pages/Main/Main.jsx
@@ -180,6 +180,7 @@ const Main = () => {
   const [click, setClick] = useState(false);
   const [path, setPath] = useState('');
   const [isMobile, setIsMobile] = useState(false);
+  const [isVideoReady, setIsVideoReady] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
 
   const assetPreloadList = useMemo(
@@ -195,6 +196,14 @@ const Main = () => {
 
   const handleClick = useCallback(() => {
     setClick((prevClick) => !prevClick);
+  }, []);
+
+  useEffect(() => {
+    setIsVideoReady(false);
+  }, [click]);
+
+  const handleVideoReady = useCallback(() => {
+    setIsVideoReady(true);
   }, []);
 
   const moveY = useMemo(() => ({ y: '-100%' }), []);
@@ -236,32 +245,36 @@ const Main = () => {
           exit={exitAnimation}
           transition={{ duration: 0.5 }}
         >
-          {prefersReducedMotion ? (
+          {prefersReducedMotion || !isVideoReady ? (
             <div className="video-placeholder" aria-hidden="true" />
-          ) : !click ? (
-            <video
-              src={videoBg}
-              autoPlay
-              loop
-              playsInline
-              muted
-              preload="auto"
-              poster={mePortrait}
-              className="video-background"
-              aria-hidden="true"
-            />
-          ) : (
-            <video
-              src={videoBg2}
-              autoPlay
-              loop
-              playsInline
-              muted
-              preload="auto"
-              playbackRate={0.5}
-              className="video-background"
-              aria-hidden="true"
-            />
+          ) : null}
+          {!prefersReducedMotion && (
+            !click ? (
+              <video
+                src={videoBg}
+                autoPlay
+                loop
+                playsInline
+                muted
+                preload="auto"
+                className={`video-background ${isVideoReady ? 'is-visible' : ''}`}
+                aria-hidden="true"
+                onLoadedData={handleVideoReady}
+              />
+            ) : (
+              <video
+                src={videoBg2}
+                autoPlay
+                loop
+                playsInline
+                muted
+                preload="auto"
+                playbackRate={0.5}
+                className={`video-background ${isVideoReady ? 'is-visible' : ''}`}
+                aria-hidden="true"
+                onLoadedData={handleVideoReady}
+              />
+            )
           )}
           <DarkDiv click={click} />
           <Container>


### PR DESCRIPTION
## Summary
- add incremental gallery rendering with lazy loading and infinite scrolling
- improve gallery loading feedback to avoid images stuck behind spinners
- smooth background video appearance with a placeholder instead of flashing poster frames

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69588cf8e7b483339888c317213921f8)