### PR TITLE
Phase 1.2 — case-study editorial template + first Magic UI primitive

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -122,6 +122,31 @@
     "lessons": "Lessons learned",
     "next": "Next steps"
   },
+  "Categories": {
+    "web-app": "Web app",
+    "game-dev": "Game development",
+    "ai-tool": "AI tool",
+    "art-film": "Art / film",
+    "experiment": "Experiment",
+    "maintenance": "Maintenance"
+  },
+  "CaseStudy": {
+    "projectsIndex": "projects",
+    "links": "Links",
+    "context": "Context",
+    "approach": "Approach",
+    "engineering": "Engineering",
+    "challenges": "Challenges",
+    "process": "Process",
+    "outcomeEyebrow": "Outcome",
+    "lessonsEyebrow": "What I learned",
+    "nextEyebrow": "Next steps",
+    "relatedWork": "Related work",
+    "moreFromCategory": "More case studies from this category coming soon.",
+    "previous": "Previous project",
+    "next": "Next project",
+    "backToArchive": "Back to archive"
+  },
   "About": {
     "title": "About Mark",
     "intro": "A China to Canada software and art path shaped by Western University, J.D. Power, game development, and a sustained interest in systems that feel human."

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -122,6 +122,31 @@
     "lessons": "复盘",
     "next": "下一步"
   },
+  "Categories": {
+    "web-app": "Web 应用",
+    "game-dev": "游戏开发",
+    "ai-tool": "AI 工具",
+    "art-film": "艺术 / 影像",
+    "experiment": "实验",
+    "maintenance": "维护"
+  },
+  "CaseStudy": {
+    "projectsIndex": "项目档案",
+    "links": "链接",
+    "context": "背景",
+    "approach": "方法",
+    "engineering": "工程实现",
+    "challenges": "挑战",
+    "process": "过程",
+    "outcomeEyebrow": "结果",
+    "lessonsEyebrow": "学到的东西",
+    "nextEyebrow": "下一步",
+    "relatedWork": "相关案例",
+    "moreFromCategory": "更多同类案例即将上线。",
+    "previous": "上一个项目",
+    "next": "下一个项目",
+    "backToArchive": "返回档案"
+  },
   "About": {
     "title": "关于 Mark",
     "intro": "从中国到加拿大，从 Western University 到 J.D. Power，再到软件、游戏与艺术的交叉实践。Mark 关注的是有温度的系统。"

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -1,290 +1,258 @@
-import type { Metadata } from "next"
-import Image from "next/image"
-import { notFound } from "next/navigation"
-import { ArrowUpRight } from "lucide-react"
-import { getTranslations } from "next-intl/server"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { PageShell } from "@/components/layout/page-shell"
-import { MediaFrame } from "@/components/placeholders/media-frame"
-import { PlaceholderImage } from "@/components/placeholders/placeholder-image"
-import { DraftBadge } from "@/components/placeholders/draft-badge"
-import { FadeIn } from "@/components/motion/fade-in"
-import { Stagger, StaggerItem } from "@/components/motion/stagger"
-import { allProjects, getProject } from "@/content/projects"
-import type { Locale } from "@/i18n/routing"
-import { Link } from "@/i18n/navigation"
-import { localize } from "@/lib/content/localize"
+import type { Metadata } from "next";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { PageShell } from "@/components/layout/page-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { CaseStudyHeader } from "@/components/case-study/case-study-header";
+import {
+  CaseStudyList,
+  CaseStudySection,
+} from "@/components/case-study/case-study-section";
+import { PullQuoteBlock } from "@/components/case-study/pull-quote-block";
+import { CaseStudyFooter } from "@/components/case-study/case-study-footer";
+import { allProjects, getProject } from "@/content/projects";
+import type { Locale } from "@/i18n/routing";
+import { Link } from "@/i18n/navigation";
+import { localize } from "@/lib/content/localize";
 
 export function generateStaticParams() {
   return allProjects.flatMap((project) => [
     { locale: "en", slug: project.slug },
     { locale: "zh", slug: project.slug },
-  ])
+  ]);
 }
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ locale: Locale; slug: string }>
+  params: Promise<{ locale: Locale; slug: string }>;
 }): Promise<Metadata> {
-  const { locale, slug } = await params
-  const project = getProject(slug)
-  if (!project) return {}
+  const { locale, slug } = await params;
+  const project = getProject(slug);
+  if (!project) return {};
   return {
     title: project.seo.title,
     description: project.seo.description,
     alternates: { canonical: `/${locale}/projects/${slug}` },
-  }
+  };
 }
+
+const eyebrowMono =
+  "font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground";
 
 export default async function ProjectDetailPage({
   params,
 }: {
-  params: Promise<{ locale: Locale; slug: string }>
+  params: Promise<{ locale: Locale; slug: string }>;
 }) {
-  const { locale, slug } = await params
-  const project = getProject(slug)
-  if (!project) notFound()
+  const { locale, slug } = await params;
+  const project = getProject(slug);
+  if (!project) notFound();
 
-  const t = await getTranslations({ locale, namespace: "Projects" })
-  const localized = localize(project, locale)
-  const cover = project.screenshots[0]
-  const sections = [
-    [t("problem"), localized.problem as string],
-    [t("solution"), localized.solution as string],
-    [t("role"), localized.role as string],
-    [t("outcome"), localized.outcome as string],
-  ]
+  const tProjects = await getTranslations({ locale, namespace: "Projects" });
+  const tCase = await getTranslations({ locale, namespace: "CaseStudy" });
+  const tCategories = await getTranslations({
+    locale,
+    namespace: "Categories",
+  });
+  const localized = localize(project, locale);
+  const cover = project.screenshots[0];
+  const processShots = project.screenshots.slice(1, 9);
+
+  // Adjacent navigation in archive order — predictable, no clever sort.
+  const projectIndex = allProjects.findIndex((p) => p.slug === project.slug);
+  const prev = projectIndex > 0 ? allProjects[projectIndex - 1] : undefined;
+  const next =
+    projectIndex < allProjects.length - 1
+      ? allProjects[projectIndex + 1]
+      : undefined;
+
   const related = allProjects
-    .filter((item) => item.slug !== project.slug && item.category === project.category)
-    .slice(0, 2)
+    .filter(
+      (item) => item.slug !== project.slug && item.category === project.category,
+    )
+    .slice(0, 2);
 
   return (
     <PageShell locale={locale}>
       <article>
-        <FadeIn>
-          <section className="relative overflow-hidden border-b">
-            <div className="absolute inset-0 bg-cyber-grid opacity-35" aria-hidden="true" />
-            <div className="noise-layer absolute inset-0" aria-hidden="true" />
-            <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_24rem] lg:px-8">
-              <div>
-                <Link
-                  href="/projects"
-                  locale={locale}
-                  className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  ← projects
-                </Link>
-                <div className="mt-8 flex flex-wrap items-center gap-2">
-                  <Badge variant="outline">{project.category}</Badge>
-                  <Badge variant={project.featured ? "success" : "outline"}>{project.status}</Badge>
-                  {project.contentStatus !== "ready" ? (
-                    <DraftBadge label={project.contentStatus} />
-                  ) : null}
-                </div>
-                <h1 className="mt-5 max-w-5xl text-[clamp(2.5rem,6vw,5rem)] font-semibold leading-none text-balance">
-                  {localized.title}
-                </h1>
-                <p className="mt-6 max-w-3xl text-xl leading-8 text-muted-foreground">
-                  {localized.shortPitch as string}
-                </p>
-                <div className="mt-8 flex flex-wrap gap-3">
-                  {project.liveUrl ? (
-                    <Button asChild>
-                      <a href={project.liveUrl} target="_blank" rel="noopener noreferrer">
-                        {t("live")}
-                        <ArrowUpRight className="size-4" />
-                      </a>
-                    </Button>
-                  ) : null}
-                  {project.githubUrl ? (
-                    <Button asChild variant="outline">
-                      <a href={project.githubUrl} target="_blank" rel="noopener noreferrer">
-                        {t("source")}
-                      </a>
-                    </Button>
-                  ) : null}
-                </div>
-              </div>
+        <CaseStudyHeader
+          project={project}
+          title={localized.title}
+          shortPitch={localized.shortPitch as string}
+          role={localized.role as string}
+        />
 
-              <Card className="bg-background/70 backdrop-blur">
-                <CardHeader>
-                  <CardTitle>{t("quickFacts")}</CardTitle>
-                </CardHeader>
-                <CardContent className="grid gap-4 text-sm">
-                  <div className="grid grid-cols-2 gap-1">
-                    <span className="text-muted-foreground">Year</span>
-                    <span className="font-mono">{project.year}</span>
-                    <span className="text-muted-foreground">Category</span>
-                    <span className="capitalize">{project.category.replace("-", " ")}</span>
-                  </div>
-                  <div className="flex flex-wrap gap-2 pt-1">
-                    {project.stack.map((item) => (
-                      <Badge key={item} variant="outline">
-                        {item}
-                      </Badge>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </section>
-        </FadeIn>
-
-        <FadeIn delay={0.1}>
-          <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-            <MediaFrame eyebrow="hero media" label={cover ? "PROJECT COVER" : "MEDIA TBD"}>
+        <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
+          <BlurFade>
+            <figure className="relative aspect-[16/10] overflow-hidden rounded-lg border bg-muted">
               {cover ? (
-                <div className="relative aspect-[16/10] overflow-hidden rounded-md border bg-muted">
-                  <Image
-                    src={cover.src}
-                    alt={cover.alt}
-                    fill
-                    sizes="(min-width: 1024px) 80vw, 100vw"
-                    className="object-cover transition duration-500"
-                  />
-                </div>
+                <Image
+                  src={cover.src}
+                  alt={cover.alt}
+                  fill
+                  priority
+                  sizes="(min-width: 1280px) 1100px, 100vw"
+                  className="object-cover"
+                />
               ) : (
-                <PlaceholderImage label="PROJECT HERO MEDIA TBD" aspect="aspect-[16/10]" />
+                <PlaceholderImage
+                  label="PROJECT HERO MEDIA TBD"
+                  aspect="h-full"
+                  className="rounded-none border-0"
+                />
               )}
-            </MediaFrame>
+            </figure>
+          </BlurFade>
+        </section>
+
+        <section className="mx-auto w-full max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16">
+            <BlurFade>
+              <CaseStudySection
+                eyebrow={tCase("context")}
+                title={tProjects("problem")}
+              >
+                <p>{localized.problem as string}</p>
+              </CaseStudySection>
+            </BlurFade>
+            <BlurFade delay={0.1}>
+              <CaseStudySection
+                eyebrow={tCase("approach")}
+                title={tProjects("solution")}
+              >
+                <p>{localized.solution as string}</p>
+              </CaseStudySection>
+            </BlurFade>
+          </div>
+        </section>
+
+        <section className="border-y bg-muted/20">
+          <div className="mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-3 lg:px-8">
+            <BlurFade>
+              <Card className="h-full bg-card/80">
+                <CardHeader>
+                  <CardTitle>{tProjects("features")}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CaseStudyList items={project.features} />
+                </CardContent>
+              </Card>
+            </BlurFade>
+            <BlurFade delay={0.08}>
+              <Card className="h-full bg-card/80">
+                <CardHeader>
+                  <CardTitle>{tProjects("architecture")}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CaseStudyList items={project.architectureNotes} />
+                </CardContent>
+              </Card>
+            </BlurFade>
+            <BlurFade delay={0.16}>
+              <Card className="h-full bg-card/80">
+                <CardHeader>
+                  <CardTitle>{tCase("challenges")}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CaseStudyList items={project.challenges} />
+                </CardContent>
+              </Card>
+            </BlurFade>
+          </div>
+        </section>
+
+        {processShots.length > 0 ? (
+          <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+            <BlurFade>
+              <h2 className={eyebrowMono}>{tCase("process")}</h2>
+            </BlurFade>
+            <div className="mt-6 grid gap-4 sm:grid-cols-2">
+              {processShots.map((shot, index) => (
+                <BlurFade key={`${index}-${shot.src}`} delay={0.05 * index}>
+                  <figure className="relative aspect-[4/3] overflow-hidden rounded-md border bg-muted">
+                    <Image
+                      src={shot.src}
+                      alt={shot.alt}
+                      fill
+                      sizes="(min-width: 768px) 540px, 100vw"
+                      className="object-cover"
+                    />
+                  </figure>
+                </BlurFade>
+              ))}
+            </div>
           </section>
-        </FadeIn>
+        ) : null}
 
-        <section className="mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-8">
-          <Stagger className="grid gap-5 lg:grid-cols-2" delay={0.05}>
-            {sections.map(([title, body]) => (
-              <StaggerItem key={title}>
-                <Card className="h-full bg-card/80">
-                  <CardHeader>
-                    <CardTitle>{title}</CardTitle>
-                  </CardHeader>
-                  <CardContent className="text-base leading-8 text-muted-foreground">{body}</CardContent>
-                </Card>
-              </StaggerItem>
-            ))}
-          </Stagger>
+        {project.outcome ? (
+          <section className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+            <BlurFade>
+              <PullQuoteBlock
+                eyebrow={tCase("outcomeEyebrow")}
+                quote={localized.outcome as string}
+              />
+            </BlurFade>
+          </section>
+        ) : null}
 
-          <Stagger className="mt-5 grid gap-5 lg:grid-cols-3" delay={0.05}>
-            <StaggerItem>
-              <Card className="h-full bg-card/80">
-                <CardHeader>
-                  <CardTitle>{t("features")}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="grid gap-2 text-sm leading-6 text-muted-foreground">
-                    {project.features.map((item) => (
-                      <li key={item} className="flex gap-2">
-                        <span className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </StaggerItem>
-            <StaggerItem>
-              <Card className="h-full bg-card/80">
-                <CardHeader>
-                  <CardTitle>{t("architecture")}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="grid gap-2 text-sm leading-6 text-muted-foreground">
-                    {project.architectureNotes.map((item) => (
-                      <li key={item} className="flex gap-2">
-                        <span className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </StaggerItem>
-            <StaggerItem>
-              <Card className="h-full bg-card/80">
-                <CardHeader>
-                  <CardTitle>Challenges</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="grid gap-2 text-sm leading-6 text-muted-foreground">
-                    {project.challenges.map((item) => (
-                      <li key={item} className="flex gap-2">
-                        <span className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </StaggerItem>
-          </Stagger>
+        <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16">
+            {project.lessonsLearned.length > 0 ? (
+              <BlurFade>
+                <CaseStudySection
+                  eyebrow={tCase("lessonsEyebrow")}
+                  title={tProjects("lessons")}
+                >
+                  <CaseStudyList items={project.lessonsLearned} numbered />
+                </CaseStudySection>
+              </BlurFade>
+            ) : null}
+            {project.nextSteps.length > 0 ? (
+              <BlurFade delay={0.1}>
+                <CaseStudySection
+                  eyebrow={tCase("nextEyebrow")}
+                  title={tProjects("next")}
+                >
+                  <CaseStudyList items={project.nextSteps} numbered />
+                </CaseStudySection>
+              </BlurFade>
+            ) : null}
+          </div>
+        </section>
 
-          <Stagger className="mt-5 grid gap-5 lg:grid-cols-2" delay={0.05}>
-            <StaggerItem>
-              <Card className="h-full bg-card/80">
-                <CardHeader>
-                  <CardTitle>{t("lessons")}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="grid gap-2 text-sm leading-6 text-muted-foreground">
-                    {project.lessonsLearned.map((item) => (
-                      <li key={item} className="flex gap-2">
-                        <span className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </StaggerItem>
-            <StaggerItem>
-              <Card className="h-full bg-card/80">
-                <CardHeader>
-                  <CardTitle>{t("next")}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="grid gap-2 text-sm leading-6 text-muted-foreground">
-                    {project.nextSteps.map((item) => (
-                      <li key={item} className="flex gap-2">
-                        <span className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </StaggerItem>
-          </Stagger>
-
-          <FadeIn delay={0.1}>
-            <div className="mt-12">
-              <h2 className="text-2xl font-semibold">Related work</h2>
-              <div className="mt-5 grid gap-4 md:grid-cols-2">
-                {related.length ? (
-                  related.map((item) => (
-                    <Link
-                      key={item.slug}
-                      href={`/projects/${item.slug}`}
-                      locale={locale}
-                      className="rounded-lg border bg-card/80 p-5 transition-colors hover:border-ring hover:shadow-md"
-                    >
-                      <Badge variant="outline">{item.category}</Badge>
-                      <h3 className="mt-3 text-xl font-semibold">{item.title}</h3>
-                      <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.shortPitch}</p>
-                    </Link>
-                  ))
-                ) : (
-                  <p className="text-sm text-muted-foreground md:col-span-2">
-                    More case studies from this category coming soon.
-                  </p>
-                )}
+        {related.length > 0 ? (
+          <section className="border-t bg-muted/20">
+            <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+              <h2 className={eyebrowMono}>{tCase("relatedWork")}</h2>
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                {related.map((item) => (
+                  <Link
+                    key={item.slug}
+                    href={`/projects/${item.slug}`}
+                    className="group rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  >
+                    <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                      {tCategories(item.category)}
+                    </p>
+                    <h3 className="mt-3 text-lg font-semibold leading-snug">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">
+                      {item.shortPitch}
+                    </p>
+                  </Link>
+                ))}
               </div>
             </div>
-          </FadeIn>
-        </section>
+          </section>
+        ) : null}
+
+        <CaseStudyFooter prev={prev} next={next} />
       </article>
     </PageShell>
-  )
+  );
 }

--- a/src/components/case-study/case-study-footer.tsx
+++ b/src/components/case-study/case-study-footer.tsx
@@ -1,0 +1,82 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
+import type { Project } from "@/content/schemas";
+
+interface CaseStudyFooterProps {
+  prev?: Project;
+  next?: Project;
+}
+
+export async function CaseStudyFooter({ prev, next }: CaseStudyFooterProps) {
+  const t = await getTranslations("CaseStudy");
+
+  return (
+    <footer className="border-t bg-muted/20">
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-6 lg:grid-cols-[1fr_auto_1fr]">
+          <CaseStudyAdjacent
+            project={prev}
+            direction="prev"
+            label={t("previous")}
+          />
+          <div className="hidden lg:block lg:self-center">
+            <Button asChild variant="outline">
+              <Link href="/projects">{t("backToArchive")}</Link>
+            </Button>
+          </div>
+          <CaseStudyAdjacent
+            project={next}
+            direction="next"
+            label={t("next")}
+          />
+        </div>
+        <div className="mt-8 flex justify-center lg:hidden">
+          <Button asChild variant="outline">
+            <Link href="/projects">{t("backToArchive")}</Link>
+          </Button>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function CaseStudyAdjacent({
+  project,
+  direction,
+  label,
+}: {
+  project: Project | undefined;
+  direction: "prev" | "next";
+  label: string;
+}) {
+  if (!project) {
+    return <div className="hidden lg:block" aria-hidden="true" />;
+  }
+
+  const isNext = direction === "next";
+
+  return (
+    <Link
+      href={`/projects/${project.slug}`}
+      className={`group flex flex-col gap-2 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+        isNext ? "lg:text-right" : ""
+      }`}
+    >
+      <span
+        className={`flex items-center gap-1.5 font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground ${
+          isNext ? "lg:justify-end" : ""
+        }`}
+      >
+        {!isNext ? <ArrowLeft aria-hidden="true" className="size-3" /> : null}
+        {label}
+        {isNext ? <ArrowRight aria-hidden="true" className="size-3" /> : null}
+      </span>
+      <span className="text-lg font-semibold leading-snug">{project.title}</span>
+      <span className="line-clamp-2 text-sm leading-6 text-muted-foreground">
+        {project.shortPitch}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/case-study/case-study-header.tsx
+++ b/src/components/case-study/case-study-header.tsx
@@ -1,0 +1,112 @@
+import { ArrowUpRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import type { Project } from "@/content/schemas";
+
+interface CaseStudyHeaderProps {
+  project: Project;
+  title: string;
+  shortPitch: string;
+  role: string;
+}
+
+export async function CaseStudyHeader({
+  project,
+  title,
+  shortPitch,
+  role,
+}: CaseStudyHeaderProps) {
+  const t = await getTranslations("CaseStudy");
+  const tProjects = await getTranslations("Projects");
+  const tCategories = await getTranslations("Categories");
+
+  return (
+    <section className="relative overflow-hidden border-b">
+      <div className="absolute inset-0 bg-cyber-grid opacity-30" aria-hidden="true" />
+      <div className="archive-vignette absolute inset-0" aria-hidden="true" />
+      <div className="relative mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <Link
+          href="/projects"
+          className="font-mono text-[0.7rem] uppercase tracking-[0.24em] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          ← {t("projectsIndex")}
+        </Link>
+
+        <div className="mt-10 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{tCategories(project.category)}</Badge>
+          <span className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+            {project.year}
+          </span>
+          <Badge variant={project.status === "ready" ? "success" : "outline"}>
+            {project.status}
+          </Badge>
+          {project.contentStatus !== "ready" ? (
+            <DraftBadge label={project.contentStatus} />
+          ) : null}
+        </div>
+
+        <h1 className="mt-6 max-w-5xl text-balance font-[family-name:var(--font-display)] text-[clamp(2.5rem,6vw,5.5rem)] font-semibold leading-[0.95] tracking-tight">
+          {title}
+        </h1>
+
+        <p className="mt-7 max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {shortPitch}
+        </p>
+
+        <dl className="mt-10 grid gap-6 border-t pt-6 sm:grid-cols-[auto_1fr] sm:gap-x-10">
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            {tProjects("role")}
+          </dt>
+          <dd className="text-sm leading-7 text-foreground">{role}</dd>
+
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            {tProjects("stack")}
+          </dt>
+          <dd className="flex flex-wrap gap-1.5">
+            {project.stack.map((item) => (
+              <Badge key={item} variant="outline" className="text-[0.65rem]">
+                {item}
+              </Badge>
+            ))}
+          </dd>
+
+          {project.liveUrl || project.githubUrl ? (
+            <>
+              <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                {t("links")}
+              </dt>
+              <dd className="flex flex-wrap gap-2">
+                {project.liveUrl ? (
+                  <Button asChild size="sm">
+                    <a
+                      href={project.liveUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {tProjects("live")}
+                      <ArrowUpRight aria-hidden="true" className="size-3.5" />
+                    </a>
+                  </Button>
+                ) : null}
+                {project.githubUrl ? (
+                  <Button asChild size="sm" variant="outline">
+                    <a
+                      href={project.githubUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {tProjects("source")}
+                    </a>
+                  </Button>
+                ) : null}
+              </dd>
+            </>
+          ) : null}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/src/components/case-study/case-study-section.tsx
+++ b/src/components/case-study/case-study-section.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib/utils";
+
+interface CaseStudySectionProps {
+  eyebrow?: string;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+  as?: "h2" | "h3";
+}
+
+const monoEyebrow =
+  "font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground";
+
+/**
+ * Editorial wrapper for prose-heavy sections of a case study.
+ * Owns the eyebrow + heading rhythm so the page composition stays consistent.
+ */
+export function CaseStudySection({
+  eyebrow,
+  title,
+  children,
+  className,
+  as = "h2",
+}: CaseStudySectionProps) {
+  const Heading = as;
+  return (
+    <section className={cn("max-w-3xl", className)}>
+      {eyebrow ? <p className={monoEyebrow}>{eyebrow}</p> : null}
+      <Heading className="mt-3 text-2xl font-semibold leading-snug text-balance sm:text-3xl">
+        {title}
+      </Heading>
+      <div className="mt-5 text-base leading-8 text-muted-foreground">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+interface CaseStudyListProps {
+  items: string[];
+  numbered?: boolean;
+  className?: string;
+}
+
+export function CaseStudyList({ items, numbered, className }: CaseStudyListProps) {
+  if (items.length === 0) return null;
+  if (numbered) {
+    return (
+      <ol className={cn("grid gap-3", className)}>
+        {items.map((item, index) => (
+          <li
+            key={`${index}-${item}`}
+            className="grid grid-cols-[2.25rem_1fr] items-start gap-3"
+          >
+            <span className="pt-1 font-mono text-[0.65rem] uppercase tracking-[0.16em] text-muted-foreground">
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <span className="text-base leading-7 text-foreground">{item}</span>
+          </li>
+        ))}
+      </ol>
+    );
+  }
+  return (
+    <ul className={cn("grid gap-2.5", className)}>
+      {items.map((item, index) => (
+        <li
+          key={`${index}-${item}`}
+          className="flex gap-3 text-sm leading-7 text-muted-foreground"
+        >
+          <span
+            aria-hidden="true"
+            className="mt-2.5 size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+          />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/case-study/pull-quote-block.tsx
+++ b/src/components/case-study/pull-quote-block.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+
+interface PullQuoteBlockProps {
+  eyebrow?: string;
+  quote: string;
+  attribution?: string;
+  className?: string;
+}
+
+/**
+ * Editorial pull-quote. Used once per case study, typically over the
+ * "outcome" block. Display family, generous measure, no decoration.
+ */
+export function PullQuoteBlock({
+  eyebrow,
+  quote,
+  attribution,
+  className,
+}: PullQuoteBlockProps) {
+  return (
+    <figure
+      className={cn(
+        "relative mx-auto max-w-4xl border-y py-12 sm:py-16",
+        className,
+      )}
+    >
+      {eyebrow ? (
+        <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
+          {eyebrow}
+        </p>
+      ) : null}
+      <blockquote className="mt-4 text-balance font-[family-name:var(--font-display)] text-2xl font-medium leading-tight tracking-tight text-foreground sm:text-3xl lg:text-4xl">
+        {quote}
+      </blockquote>
+      {attribution ? (
+        <figcaption className="mt-6 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          — {attribution}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/src/components/ui/magic/blur-fade.tsx
+++ b/src/components/ui/magic/blur-fade.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+// Adapted from Magic UI · BlurFade · phase 1.2 redesign
+
+import { useRef } from "react";
+import { motion, useInView, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface BlurFadeProps {
+  children: React.ReactNode;
+  delay?: number;
+  duration?: number;
+  blur?: string;
+  className?: string;
+  once?: boolean;
+}
+
+export function BlurFade({
+  children,
+  delay = 0,
+  duration = 0.5,
+  blur = "6px",
+  className,
+  once = true,
+}: BlurFadeProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once, margin: "-60px" });
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) {
+    return (
+      <div ref={ref} className={cn(className)}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, filter: `blur(${blur})`, y: 8 }}
+      animate={inView ? { opacity: 1, filter: "blur(0px)", y: 0 } : {}}
+      // Cubic-bezier mirrors --ease-premium; motion's transition.ease cannot read CSS variables.
+      transition={{ delay, duration, ease: [0.2, 0.7, 0.2, 1] }}
+      className={cn(className)}
+    >
+      {children}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 1.2 of the m4rkyu.com redesign. Refactors `/[locale]/projects/[slug]`
from a wall of equal-weight cards into the editorial template specified in
[`docs/COMPONENT_MAP.md` §6](../blob/main/docs/COMPONENT_MAP.md), and lands
the first Magic UI primitive (`BlurFade`) tokenized to the project's
conventions.

Single feature commit — bounded scope so the diff stays reviewable.

## What changed

### New components (`src/components/case-study/*`)
- **CaseStudyHeader** — eyebrow (category · year · status) + display headline
  + lede + role/stack/live+repo links ribbon. Owns the only `<h1>` on the
  page. Categories now route through a new `Categories` translation
  namespace instead of leaking the raw enum (`web-app` → `Web app` /
  `Web 应用`).
- **CaseStudySection + CaseStudyList** — typed wrappers for prose blocks and
  for both bulleted (`<ul>`) and numbered (`<ol>` with mono numerals) lists.
- **PullQuoteBlock** — display-font outcome block, semantic `<figure>` +
  `<blockquote>` + optional `<figcaption>`.
- **CaseStudyFooter** — prev / next adjacent navigation in archive order +
  back-to-archive pill, mobile-stacked.

### New primitive (`src/components/ui/magic/blur-fade.tsx`)
- Tokenized Magic UI copy-in. Cubic-bezier mirrors `--ease-premium` with a
  comment explaining why (motion's `transition.ease` cannot read CSS vars).
- Honors `prefers-reduced-motion` via `useReducedMotion()` — short-circuits
  to a static `<div>` for users who opted out.
- No new package added; depends only on `motion/react` which is already in
  the runtime.

### Refactored
- `src/app/[locale]/projects/[slug]/page.tsx` — recomposed into the
  10-block editorial template (header → hero figure → paired
  Problem/Solution → 3-card details strip → process gallery → pull-quote
  outcome → Lessons + Next steps → Related work → footer).

### Translations (`messages/{en,zh}.json`)
- New **`CaseStudy`** namespace: `projectsIndex`, `links`, `context`,
  `approach`, `challenges`, `process`, `outcomeEyebrow`, `lessonsEyebrow`,
  `nextEyebrow`, `relatedWork`, `previous`, `next`, `backToArchive`.
- New **`Categories`** namespace: mirrors `projectSchema`'s category enum so
  display strings stay editorial in both locales.

## Phase 1 patterns applied up front
Documented in global memory after Phase 1's review pass. All applied here:

- All visible strings translated from line 1 (no English-only retrofits).
- Locale prop dropped from any component that doesn't read it.
- `aria-hidden="true"` on every decorative lucide icon.
- Real `<h1>` in header, real `<h2>` on Process and Related Work
  (mono-styled but semantically still `h2` — document outline preserved).
- All external `<a>` carry `rel="noopener noreferrer"`.
- Tokens only: `--ring`, `--motion-fast`, `--ease-premium`,
  `border-border`, `bg-card`, `bg-muted/20`. No `bg-zinc-*`, no hex.

## Test plan

- [ ] Visit `/en/projects/nimbus`, `/zh/projects/nimbus` — header reads
      "Web app" / "Web 应用", outline visible (h1 → h2 → h3).
- [ ] Visit a project with no `outcome` — pull-quote section is omitted
      cleanly.
- [ ] Visit first project — prev side of footer hides without breaking
      layout; visit last project — same for next.
- [ ] Toggle `prefers-reduced-motion` — BlurFade short-circuits, no
      filter/transform.
- [ ] Resize to 360px — header collapses, lists wrap, footer stacks.

## Out of scope (Phase 1.3+)

- Game detail template (same shape, different metadata) — fold in once
  this template is locked.
- Project archive page polish (`/projects` index) — Phase 1.3.
- Blog / devlog redesign — Phase 1.3.
- Likes backend (Upstash KV) — pending key/secret from owner.
- Storybook entries for the four new case-study components — `LATER` in
  the review; will land alongside Phase 1.3 to keep this PR tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)