### PR TITLE
Phase 1.3 — game detail editorial template + games archive polish

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -122,6 +122,25 @@
     "lessons": "Lessons learned",
     "next": "Next steps"
   },
+  "Game": {
+    "gamesIndex": "games",
+    "eyebrow": "game systems",
+    "intro": "Game-development archive for prototypes, engine studies, and future interactive work.",
+    "metaDescription": "Game-development archive by ZhenXiao Mark Yu.",
+    "platforms": "Platforms",
+    "buildLinks": "Build links",
+    "pillarsEyebrow": "Design pillars",
+    "pillarsTitle": "What this game is about",
+    "postmortemEyebrow": "Postmortem",
+    "postmortemTitle": "Notes after the build",
+    "notesEyebrow": "Design notes",
+    "notesTitle": "Working notes",
+    "archiveStatus": "Archive status",
+    "production": "production entries",
+    "draft": "in development or planned",
+    "noClaims": "No fabricated platforms, awards, or build claims included.",
+    "coverTbd": "GAME COVER TBD"
+  },
   "Categories": {
     "web-app": "Web app",
     "game-dev": "Game development",
@@ -143,8 +162,8 @@
     "nextEyebrow": "Next steps",
     "relatedWork": "Related work",
     "moreFromCategory": "More case studies from this category coming soon.",
-    "previous": "Previous project",
-    "next": "Next project",
+    "previous": "Previous",
+    "next": "Next",
     "backToArchive": "Back to archive"
   },
   "About": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -122,6 +122,25 @@
     "lessons": "复盘",
     "next": "下一步"
   },
+  "Game": {
+    "gamesIndex": "游戏档案",
+    "eyebrow": "游戏系统",
+    "intro": "面向原型、引擎研究与未来交互作品的游戏开发档案。",
+    "metaDescription": "于震潇的游戏开发档案。",
+    "platforms": "平台",
+    "buildLinks": "构建链接",
+    "pillarsEyebrow": "设计支柱",
+    "pillarsTitle": "这款游戏的核心",
+    "postmortemEyebrow": "复盘",
+    "postmortemTitle": "构建之后的笔记",
+    "notesEyebrow": "设计笔记",
+    "notesTitle": "工作记录",
+    "archiveStatus": "档案状态",
+    "production": "已上线条目",
+    "draft": "开发中或计划中",
+    "noClaims": "不包含虚构的平台、奖项或构建声明。",
+    "coverTbd": "游戏封面待定"
+  },
   "Categories": {
     "web-app": "Web 应用",
     "game-dev": "游戏开发",
@@ -143,8 +162,8 @@
     "nextEyebrow": "下一步",
     "relatedWork": "相关案例",
     "moreFromCategory": "更多同类案例即将上线。",
-    "previous": "上一个项目",
-    "next": "下一个项目",
+    "previous": "上一篇",
+    "next": "下一篇",
     "backToArchive": "返回档案"
   },
   "About": {

--- a/src/app/[locale]/games/[slug]/page.tsx
+++ b/src/app/[locale]/games/[slug]/page.tsx
@@ -1,14 +1,18 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import { notFound } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getTranslations } from "next-intl/server";
 import { PageShell } from "@/components/layout/page-shell";
-import { SectionHeading } from "@/components/sections/section-heading";
-import { MediaFrame } from "@/components/placeholders/media-frame";
-import { PlaceholderVideo } from "@/components/placeholders/placeholder-video";
-import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { GameDetailHeader } from "@/components/case-study/game-detail-header";
+import {
+  CaseStudyList,
+  CaseStudySection,
+} from "@/components/case-study/case-study-section";
+import { PullQuoteBlock } from "@/components/case-study/pull-quote-block";
+import { CaseStudyFooter } from "@/components/case-study/case-study-footer";
 import { games } from "@/content/games";
-import { Link } from "@/i18n/navigation";
 import type { Locale } from "@/i18n/routing";
 
 export function generateStaticParams() {
@@ -21,13 +25,15 @@ export function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: Locale; slug: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
+  const { locale, slug } = await params;
   const game = games.find((item) => item.slug === slug);
+  if (!game) return {};
   return {
-    title: game ? game.title : "Game",
-    description: game ? game.pitch : "Draft game archive page.",
+    title: game.title,
+    description: game.pitch,
+    alternates: { canonical: `/${locale}/games/${slug}` },
   };
 }
 
@@ -40,45 +46,111 @@ export default async function GameDetailPage({
   const game = games.find((item) => item.slug === slug);
   if (!game) notFound();
 
+  const tGame = await getTranslations({ locale, namespace: "Game" });
+  const tCase = await getTranslations({ locale, namespace: "CaseStudy" });
+
+  // Adjacent navigation in archive order — predictable, no clever sort.
+  const gameIndex = games.findIndex((g) => g.slug === game.slug);
+  const prevGame = gameIndex > 0 ? games[gameIndex - 1] : undefined;
+  const nextGame =
+    gameIndex < games.length - 1 ? games[gameIndex + 1] : undefined;
+  const prev = prevGame
+    ? {
+        href: `/games/${prevGame.slug}`,
+        title: prevGame.title,
+        pitch: prevGame.pitch,
+      }
+    : undefined;
+  const next = nextGame
+    ? {
+        href: `/games/${nextGame.slug}`,
+        title: nextGame.title,
+        pitch: nextGame.pitch,
+      }
+    : undefined;
+
   return (
     <PageShell locale={locale}>
-      <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-        <Link href="/games" locale={locale} className="text-sm text-muted-foreground hover:text-foreground">
-          / games
-        </Link>
-        <div className="mt-8 grid gap-10 lg:grid-cols-[1fr_24rem]">
-          <SectionHeading eyebrow="game archive" title={game.title} description={game.pitch} />
-          <Card className="bg-card/80">
-            <CardHeader>
-              <DraftBadge label={game.status} />
-              <CardTitle>Build facts</CardTitle>
-            </CardHeader>
-            <CardContent className="grid gap-3 text-sm text-muted-foreground">
-              <p>Engine: {game.engine}</p>
-              <p>Year: {game.year}</p>
-              <p>Role: {game.role}</p>
-            </CardContent>
-          </Card>
-        </div>
-        <div className="mt-10 grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-          <MediaFrame eyebrow="gameplay" label="CAPTURE TBD">
-            <PlaceholderVideo label="GAMEPLAY VIDEO TBD" />
-          </MediaFrame>
-          <Card className="bg-card/80">
-            <CardHeader>
-              <Badge variant="outline">Design notes</Badge>
-              <CardTitle>Content pending</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="grid gap-3 text-sm leading-6 text-muted-foreground">
-                {game.notes.map((note) => (
-                  <li key={note}>{note}</li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
+      <article>
+        <GameDetailHeader game={game} />
+
+        <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
+          <BlurFade>
+            <figure className="relative aspect-[16/10] overflow-hidden rounded-lg border bg-muted">
+              {game.cover ? (
+                <Image
+                  src={game.cover.src}
+                  alt={game.cover.alt}
+                  fill
+                  priority
+                  sizes="(min-width: 1280px) 1100px, 100vw"
+                  className="object-cover"
+                />
+              ) : (
+                <PlaceholderImage
+                  label={tGame("coverTbd")}
+                  aspect="h-full"
+                  className="rounded-none border-0"
+                />
+              )}
+            </figure>
+          </BlurFade>
+        </section>
+
+        {game.pillars.length > 0 ? (
+          <section className="border-y bg-muted/20">
+            <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+              <BlurFade>
+                <CaseStudySection
+                  eyebrow={tGame("pillarsEyebrow")}
+                  title={tGame("pillarsTitle")}
+                >
+                  <CaseStudyList items={game.pillars} numbered />
+                </CaseStudySection>
+              </BlurFade>
+            </div>
+          </section>
+        ) : null}
+
+        {game.outcome ? (
+          <section className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+            <BlurFade>
+              <PullQuoteBlock
+                eyebrow={tCase("outcomeEyebrow")}
+                quote={game.outcome}
+              />
+            </BlurFade>
+          </section>
+        ) : null}
+
+        {game.postmortem ? (
+          <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+            <BlurFade>
+              <CaseStudySection
+                eyebrow={tGame("postmortemEyebrow")}
+                title={tGame("postmortemTitle")}
+              >
+                <p>{game.postmortem}</p>
+              </CaseStudySection>
+            </BlurFade>
+          </section>
+        ) : null}
+
+        {game.notes.length > 0 ? (
+          <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+            <BlurFade>
+              <CaseStudySection
+                eyebrow={tGame("notesEyebrow")}
+                title={tGame("notesTitle")}
+              >
+                <CaseStudyList items={game.notes} />
+              </CaseStudySection>
+            </BlurFade>
+          </section>
+        ) : null}
+
+        <CaseStudyFooter prev={prev} next={next} archiveHref="/games" />
+      </article>
     </PageShell>
   );
 }

--- a/src/app/[locale]/games/page.tsx
+++ b/src/app/[locale]/games/page.tsx
@@ -1,63 +1,90 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { ArchiveCard } from "@/components/cards/archive-card";
 import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { PlaceholderVideo } from "@/components/placeholders/placeholder-video";
+import { FadeIn } from "@/components/motion/fade-in";
+import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { games } from "@/content/games";
 import type { Locale } from "@/i18n/routing";
 
-export const metadata: Metadata = {
-  title: "Games",
-  description: "Draft game-development archive for M4rkyu.com.",
-};
-
-export default async function GamesPage({ params }: { params: Promise<{ locale: Locale }> }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
   const { locale } = await params;
+  const tNav = await getTranslations({ locale, namespace: "Navigation" });
+  const tGame = await getTranslations({ locale, namespace: "Game" });
+  return {
+    title: tNav("games"),
+    description: tGame("metaDescription"),
+    alternates: { canonical: `/${locale}/games` },
+  };
+}
+
+export default async function GamesPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  const tNav = await getTranslations({ locale, namespace: "Navigation" });
+  const tGame = await getTranslations({ locale, namespace: "Game" });
+  const readyCount = games.filter((g) => g.status === "ready").length;
+  const draftCount = games.length - readyCount;
 
   return (
     <PageShell locale={locale}>
       <section className="relative overflow-hidden border-b">
         <div className="absolute inset-0 bg-cyber-grid opacity-35" aria-hidden="true" />
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
-        <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_0.9fr] lg:px-8">
-          <SectionHeading
-            eyebrow="game systems"
-            title="Games"
-            description="Draft game archive for prototypes, Unreal studies, and future interactive work. All uncertain details are marked TBD or Placeholder."
-          />
-          <PlaceholderVideo label="GAME REEL TBD" />
-        </div>
-      </section>
-      <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-        <div className="grid gap-5 md:grid-cols-3">
-          {games.map((game) => (
-            <ArchiveCard
-              key={game.slug}
-              title={game.title}
-              description={game.pitch}
-              eyebrow={game.engine}
-              status={game.status}
-              href={`/games/${game.slug}`}
-              locale={locale}
-              mediaLabel="GAME CAPTURE TBD"
+        <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_22rem] lg:px-8">
+          <FadeIn>
+            <SectionHeading
+              eyebrow={tGame("eyebrow")}
+              title={tNav("games")}
+              description={tGame("intro")}
             />
-          ))}
+          </FadeIn>
+          <FadeIn direction="left" delay={0.1}>
+            <Card className="bg-background/70 backdrop-blur">
+              <CardHeader>
+                <CardTitle>{tGame("archiveStatus")}</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-3 text-sm text-muted-foreground">
+                <p>
+                  <span className="font-mono text-foreground">{readyCount}</span>{" "}
+                  {tGame("production")}
+                </p>
+                <p>
+                  <span className="font-mono text-foreground">{draftCount}</span>{" "}
+                  {tGame("draft")}
+                </p>
+                <p>{tGame("noClaims")}</p>
+              </CardContent>
+            </Card>
+          </FadeIn>
         </div>
       </section>
-      <section className="mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-8">
-        <Card className="bg-card/80">
-          <CardHeader>
-            <Badge variant="warning">Draft</Badge>
-            <CardTitle>Game-page acceptance notes</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-2 text-sm leading-6 text-muted-foreground md:grid-cols-3">
-            <p>No WebGL is loaded on this route.</p>
-            <p>Gameplay media is represented by static placeholder frames.</p>
-            <p>Final engine details and claims remain TBD until verified.</p>
-          </CardContent>
-        </Card>
+
+      <section className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 lg:px-8">
+        <Stagger className="grid gap-5 md:grid-cols-2 lg:grid-cols-3" delay={0.05}>
+          {games.map((game) => (
+            <StaggerItem key={game.slug}>
+              <ArchiveCard
+                title={game.title}
+                description={game.pitch}
+                eyebrow={game.engine}
+                status={game.status}
+                href={`/games/${game.slug}`}
+                locale={locale}
+                mediaLabel={tGame("coverTbd")}
+              />
+            </StaggerItem>
+          ))}
+        </Stagger>
       </section>
     </PageShell>
   );

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -64,11 +64,25 @@ export default async function ProjectDetailPage({
 
   // Adjacent navigation in archive order — predictable, no clever sort.
   const projectIndex = allProjects.findIndex((p) => p.slug === project.slug);
-  const prev = projectIndex > 0 ? allProjects[projectIndex - 1] : undefined;
-  const next =
+  const prevProject = projectIndex > 0 ? allProjects[projectIndex - 1] : undefined;
+  const nextProject =
     projectIndex < allProjects.length - 1
       ? allProjects[projectIndex + 1]
       : undefined;
+  const prev = prevProject
+    ? {
+        href: `/projects/${prevProject.slug}`,
+        title: prevProject.title,
+        pitch: prevProject.shortPitch,
+      }
+    : undefined;
+  const next = nextProject
+    ? {
+        href: `/projects/${nextProject.slug}`,
+        title: nextProject.title,
+        pitch: nextProject.shortPitch,
+      }
+    : undefined;
 
   const related = allProjects
     .filter(
@@ -251,7 +265,7 @@ export default async function ProjectDetailPage({
           </section>
         ) : null}
 
-        <CaseStudyFooter prev={prev} next={next} />
+        <CaseStudyFooter prev={prev} next={next} archiveHref="/projects" />
       </article>
     </PageShell>
   );

--- a/src/components/case-study/case-study-footer.tsx
+++ b/src/components/case-study/case-study-footer.tsx
@@ -2,14 +2,29 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
-import type { Project } from "@/content/schemas";
 
-interface CaseStudyFooterProps {
-  prev?: Project;
-  next?: Project;
+export interface CaseStudyAdjacentEntry {
+  href: string;
+  title: string;
+  pitch: string;
 }
 
-export async function CaseStudyFooter({ prev, next }: CaseStudyFooterProps) {
+interface CaseStudyFooterProps {
+  prev?: CaseStudyAdjacentEntry;
+  next?: CaseStudyAdjacentEntry;
+  archiveHref: string;
+}
+
+/**
+ * Shared editorial footer for case-study-style detail pages
+ * (projects, games). Consumer formats the prev/next entries from
+ * its own data shape — the footer is route-agnostic.
+ */
+export async function CaseStudyFooter({
+  prev,
+  next,
+  archiveHref,
+}: CaseStudyFooterProps) {
   const t = await getTranslations("CaseStudy");
 
   return (
@@ -17,24 +32,24 @@ export async function CaseStudyFooter({ prev, next }: CaseStudyFooterProps) {
       <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="grid gap-6 lg:grid-cols-[1fr_auto_1fr]">
           <CaseStudyAdjacent
-            project={prev}
+            entry={prev}
             direction="prev"
             label={t("previous")}
           />
           <div className="hidden lg:block lg:self-center">
             <Button asChild variant="outline">
-              <Link href="/projects">{t("backToArchive")}</Link>
+              <Link href={archiveHref}>{t("backToArchive")}</Link>
             </Button>
           </div>
           <CaseStudyAdjacent
-            project={next}
+            entry={next}
             direction="next"
             label={t("next")}
           />
         </div>
         <div className="mt-8 flex justify-center lg:hidden">
           <Button asChild variant="outline">
-            <Link href="/projects">{t("backToArchive")}</Link>
+            <Link href={archiveHref}>{t("backToArchive")}</Link>
           </Button>
         </div>
       </div>
@@ -43,15 +58,15 @@ export async function CaseStudyFooter({ prev, next }: CaseStudyFooterProps) {
 }
 
 function CaseStudyAdjacent({
-  project,
+  entry,
   direction,
   label,
 }: {
-  project: Project | undefined;
+  entry: CaseStudyAdjacentEntry | undefined;
   direction: "prev" | "next";
   label: string;
 }) {
-  if (!project) {
+  if (!entry) {
     return <div className="hidden lg:block" aria-hidden="true" />;
   }
 
@@ -59,7 +74,7 @@ function CaseStudyAdjacent({
 
   return (
     <Link
-      href={`/projects/${project.slug}`}
+      href={entry.href}
       className={`group flex flex-col gap-2 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
         isNext ? "lg:text-right" : ""
       }`}
@@ -73,9 +88,9 @@ function CaseStudyAdjacent({
         {label}
         {isNext ? <ArrowRight aria-hidden="true" className="size-3" /> : null}
       </span>
-      <span className="text-lg font-semibold leading-snug">{project.title}</span>
+      <span className="text-lg font-semibold leading-snug">{entry.title}</span>
       <span className="line-clamp-2 text-sm leading-6 text-muted-foreground">
-        {project.shortPitch}
+        {entry.pitch}
       </span>
     </Link>
   );

--- a/src/components/case-study/game-detail-header.tsx
+++ b/src/components/case-study/game-detail-header.tsx
@@ -1,0 +1,102 @@
+import { ArrowUpRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import type { Game } from "@/content/schemas";
+
+interface GameDetailHeaderProps {
+  game: Game;
+}
+
+/**
+ * Mirrors `CaseStudyHeader`'s visual shape (cyber-grid hero +
+ * eyebrow row + display title + lede + meta ribbon) but reads
+ * game-specific fields: engine, year, role, platforms, build links.
+ */
+export async function GameDetailHeader({ game }: GameDetailHeaderProps) {
+  const t = await getTranslations("CaseStudy");
+  const tGame = await getTranslations("Game");
+  const tProjects = await getTranslations("Projects");
+
+  return (
+    <section className="relative overflow-hidden border-b">
+      <div className="absolute inset-0 bg-cyber-grid opacity-30" aria-hidden="true" />
+      <div className="archive-vignette absolute inset-0" aria-hidden="true" />
+      <div className="relative mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <Link
+          href="/games"
+          className="font-mono text-[0.7rem] uppercase tracking-[0.24em] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          ← {tGame("gamesIndex")}
+        </Link>
+
+        <div className="mt-10 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{game.engine}</Badge>
+          <span className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+            {game.year}
+          </span>
+          {game.status !== "ready" ? <DraftBadge label={game.status} /> : null}
+        </div>
+
+        <h1 className="mt-6 max-w-5xl text-balance font-[family-name:var(--font-display)] text-[clamp(2.5rem,6vw,5.5rem)] font-semibold leading-[0.95] tracking-tight">
+          {game.title}
+        </h1>
+
+        <p className="mt-7 max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {game.pitch}
+        </p>
+
+        <dl className="mt-10 grid gap-6 border-t pt-6 sm:grid-cols-[auto_1fr] sm:gap-x-10">
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            {tProjects("role")}
+          </dt>
+          <dd className="text-sm leading-7 text-foreground">{game.role}</dd>
+
+          {game.platforms.length > 0 ? (
+            <>
+              <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                {tGame("platforms")}
+              </dt>
+              <dd className="flex flex-wrap gap-1.5">
+                {game.platforms.map((item) => (
+                  <Badge key={item} variant="outline" className="text-[0.65rem]">
+                    {item}
+                  </Badge>
+                ))}
+              </dd>
+            </>
+          ) : null}
+
+          {game.buildLinks.length > 0 ? (
+            <>
+              <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                {t("links")}
+              </dt>
+              <dd className="flex flex-wrap gap-2">
+                {game.buildLinks.map((link, index) => (
+                  <Button
+                    key={`${index}-${link.url}`}
+                    asChild
+                    size="sm"
+                    variant={index === 0 ? "default" : "outline"}
+                  >
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.label}
+                      <ArrowUpRight aria-hidden="true" className="size-3.5" />
+                    </a>
+                  </Button>
+                ))}
+              </dd>
+            </>
+          ) : null}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/src/content/schemas.ts
+++ b/src/content/schemas.ts
@@ -136,6 +136,16 @@ export const gameSchema = z.object({
   pitch: z.string(),
   role: z.string(),
   notes: z.array(z.string()),
+  // Phase 1.3 additions — all optional / defaulted so existing content validates.
+  cover: imageSchema.optional(),
+  trailerUrl: z.string().url().optional(),
+  platforms: z.array(z.string()).default([]),
+  pillars: z.array(z.string()).default([]),
+  postmortem: z.string().optional(),
+  outcome: z.string().optional(),
+  buildLinks: z
+    .array(z.object({ label: z.string(), url: z.string().url() }))
+    .default([]),
 });
 
 export const mediaItemSchema = z.object({


### PR DESCRIPTION
## Summary

Phase 1.3 of the m4rkyu.com redesign. Brings `/games` and
`/games/[slug]` to parity with the projects archive + case-study
editorial template shipped in Phase 1.2 (PR #13). Single feature
commit, bounded scope.

## What changed

### Schema (`src/content/schemas.ts`)
- `gameSchema` extended with optional Phase 1.3 fields: `cover`,
  `trailerUrl`, `platforms[]`, `pillars[]`, `postmortem`, `outcome`,
  `buildLinks[]`. All defaulted/optional — existing
  `src/content/games.ts` entries (3 placeholder/draft games) validate
  without edits.

### Generalized footer
- `CaseStudyFooter` API decoupled from `Project` type. Now takes:
  `prev?: { href, title, pitch }`, `next?: { href, title, pitch }`,
  `archiveHref: string`.
- Serves both `/projects/[slug]` and `/games/[slug]`. The project
  detail page was updated atomically to format adjacent entries to
  the new shape.

### New: `GameDetailHeader` (`src/components/case-study/game-detail-header.tsx`)
- Mirrors `CaseStudyHeader`'s visual shape but reads game fields:
  engine, year, role, platforms, build links.

### Game detail page rewrite (`src/app/[locale]/games/[slug]/page.tsx`)
- From a 4-block sketch to the editorial template: `GameDetailHeader`
  → cover figure (`BlurFade`) → optional pillars (numbered list)
  → optional `PullQuoteBlock` outcome → optional postmortem prose
  → notes (bulleted list) → `CaseStudyFooter`.
- Sections collapse when their data field is empty (current games
  are placeholder/draft so most sections hide gracefully).

### Games archive polish (`src/app/[locale]/games/page.tsx`)
- Status block in right rail (`lg:grid-cols-[1fr_22rem]`) with
  \"N production / N draft\" counts — mirrors `/projects` archive.
- `generateMetadata` is now locale-aware with per-locale canonical.
- Spacing: `py-16` hero / `py-20` grid per design direction §5.

### i18n (`messages/{en,zh}.json`)
- New **`Game`** namespace; CJK hand-translated.
- `CaseStudy.previous` / `.next` generalized from \"Previous project\" /
  \"Next project\" to \"Previous\" / \"Next\" so the shared footer reads
  correctly on both projects and games.

## Phase 1 patterns applied (per `~/.claude/projects/.../feedback_phase1_patterns.md`)
- Every visible string translated; no hardcoded English on `/zh`.
- `aria-hidden=\"true\"` on every decorative lucide icon.
- Real `<h1>` only in `GameDetailHeader`.
- Tokens only: `--ring`, `--motion-fast`, `--ease-premium`,
  `border-border`, `bg-card`, `bg-muted/20`.
- External `<a>` carries `rel=\"noopener noreferrer\"`.

## Test plan

- [ ] Visit `/en/games/descent-into-madness` and
      `/zh/games/descent-into-madness` — header reads localized
      title; cover shows placeholder; pillars/outcome/postmortem
      sections hide cleanly (current data has none).
- [ ] Visit `/en/games` and `/zh/games` — status block shows
      `0 production / 3 draft`; spacing matches `/projects` archive.
- [ ] Visit `/en/projects/nimbus` — case-study page still works
      (footer API change verified).
- [ ] Resize to 360px — header meta ribbon wraps, footer stacks.

## Out of scope
- Schema `translations` field for games (parity with projects) —
  defer until games have real content.
- `HeroVideoDialog` for `trailerUrl` — schema is in place; the dialog
  primitive lands in Phase 2.x with the Magic UI atmosphere wave.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)