### PR TITLE
Phase 1.5 — blog timeline redesign

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -175,6 +175,15 @@
     "next": "Next",
     "backToArchive": "Back to archive"
   },
+  "Blog": {
+    "eyebrow": "field notes",
+    "title": "Writing & Devlog",
+    "description": "Short, dated, opinionated. Engineering notes, devlog entries, and process essays — added as content ships.",
+    "metaDescription": "Writing and devlog from ZhenXiao Mark Yu — engineering notes, design process, and game development.",
+    "tagAll": "All",
+    "pinnedEyebrow": "Pinned",
+    "noMatches": "No posts match this tag."
+  },
   "About": {
     "title": "About Mark",
     "intro": "A China to Canada software and art path shaped by Western University, J.D. Power, game development, and a sustained interest in systems that feel human."

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -175,6 +175,15 @@
     "next": "下一篇",
     "backToArchive": "返回档案"
   },
+  "Blog": {
+    "eyebrow": "随笔",
+    "title": "写作与开发日志",
+    "description": "短、有日期、有观点。工程随笔、开发日志与过程文章，随内容上线持续更新。",
+    "metaDescription": "于震潇的写作与开发日志：工程随笔、设计过程与游戏开发。",
+    "tagAll": "全部",
+    "pinnedEyebrow": "置顶",
+    "noMatches": "没有匹配此标签的文章。"
+  },
   "About": {
     "title": "关于 Mark",
     "intro": "从中国到加拿大，从 Western University 到 J.D. Power，再到软件、游戏与艺术的交叉实践。Mark 关注的是有温度的系统。"

--- a/src/app/[locale]/blog/_client.tsx
+++ b/src/app/[locale]/blog/_client.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useMemo, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PostListItem } from "@/components/cards/post-list-item";
+import type { Post } from "@/content/schemas";
+
+interface BlogTimelineProps {
+  posts: Post[];
+}
+
+const ALL_TAG = "__all__";
+
+export function BlogTimeline({ posts }: BlogTimelineProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+  const t = useTranslations("Blog");
+
+  const allTags = useMemo(
+    () => Array.from(new Set(posts.flatMap((p) => p.tags))).sort(),
+    [posts],
+  );
+  const tagParam = searchParams.get("tag");
+  const activeTag = tagParam && allTags.includes(tagParam) ? tagParam : ALL_TAG;
+
+  function setTag(tag: string) {
+    const params = new URLSearchParams(searchParams);
+    if (tag === ALL_TAG) params.delete("tag");
+    else params.set("tag", tag);
+    startTransition(() => {
+      const next = params.toString();
+      router.replace(next ? `${pathname}?${next}` : pathname, {
+        scroll: false,
+      });
+    });
+  }
+
+  const filtered =
+    activeTag === ALL_TAG
+      ? posts
+      : posts.filter((p) => p.tags.includes(activeTag));
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto p-0 hover:bg-transparent"
+          aria-pressed={activeTag === ALL_TAG}
+          onClick={() => setTag(ALL_TAG)}
+        >
+          <Badge
+            variant={activeTag === ALL_TAG ? "success" : "outline"}
+            className="cursor-pointer transition-colors"
+          >
+            {t("tagAll")}
+          </Badge>
+        </Button>
+        {allTags.map((tag) => (
+          <Button
+            key={tag}
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-auto p-0 hover:bg-transparent"
+            aria-pressed={activeTag === tag}
+            onClick={() => setTag(tag)}
+          >
+            <Badge
+              variant={activeTag === tag ? "success" : "outline"}
+              className="cursor-pointer transition-colors"
+            >
+              {tag}
+            </Badge>
+          </Button>
+        ))}
+        <span className="ml-2 font-mono text-xs text-muted-foreground">
+          {filtered.length} / {posts.length}
+        </span>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="mt-12 text-center font-mono text-sm text-muted-foreground">
+          {t("noMatches")}
+        </p>
+      ) : (
+        <ol className="mt-8 grid gap-1 divide-y divide-border/60">
+          {filtered.map((post) => (
+            <PostListItem key={post.slug} post={post} />
+          ))}
+        </ol>
+      )}
+    </>
+  );
+}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,62 +1,65 @@
-import { ArchiveCard } from "@/components/cards/archive-card";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { EmptyArchiveState } from "@/components/placeholders/empty-archive-state";
+import { PinnedPostCard } from "@/components/cards/pinned-post-card";
+import { FadeIn } from "@/components/motion/fade-in";
 import { posts } from "@/content/posts";
 import type { Locale } from "@/i18n/routing";
+import { BlogTimeline } from "./_client";
 
-export default async function BlogPage({ params }: { params: Promise<{ locale: Locale }> }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Blog" });
+  return {
+    title: t("title"),
+    description: t("metaDescription"),
+    alternates: { canonical: `/${locale}/blog` },
+  };
+}
+
+export default async function BlogPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Blog" });
+  const pinned = posts.find((post) => post.pinned);
+  const timelinePosts = posts.filter((post) => !post.pinned);
+
   return (
     <PageShell locale={locale}>
       <section className="relative overflow-hidden border-b">
         <div className="absolute inset-0 bg-cyber-grid opacity-30" aria-hidden="true" />
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
         <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-          <SectionHeading
-            eyebrow="mdx lane"
-            title="Writing / Devlogs"
-            description="Draft writing archive for technical notes, remake logs, and project essays. MDX is wired; final posts can replace these placeholders without changing the layout."
-          />
-        </div>
-      </section>
-      <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-        <div className="flex flex-wrap gap-2">
-          {["All", "Devlog", "Writing", "Game dev", "Drafts"].map((category) => (
-            <Badge key={category} variant={category === "All" ? "success" : "outline"}>
-              {category}
-            </Badge>
-          ))}
-        </div>
-        <div className="mt-8 grid gap-5 md:grid-cols-3">
-          {posts.map((post) => (
-            <ArchiveCard
-              key={post.slug}
-              title={post.title}
-              description={post.excerpt}
-              eyebrow={`${post.category} / ${post.readingTime}`}
-              status={post.status}
-              mediaLabel="POST COVER TBD"
+          <FadeIn>
+            <SectionHeading
+              eyebrow={t("eyebrow")}
+              title={t("title")}
+              description={t("description")}
             />
-          ))}
+          </FadeIn>
         </div>
       </section>
-      <section className="mx-auto grid w-full max-w-7xl gap-5 px-4 pb-20 sm:px-6 lg:grid-cols-[1fr_1fr] lg:px-8">
-        <Card className="bg-card/80">
-          <CardHeader>
-            <Badge variant="warning">Draft</Badge>
-            <CardTitle>Desktop table of contents placeholder</CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm leading-6 text-muted-foreground">
-            TBD: article detail pages will include a server-rendered heading map and a collapsed mobile TOC.
-          </CardContent>
-        </Card>
-        <EmptyArchiveState
-          title="No published MDX yet"
-          description="Draft state: final posts will appear here after case-study copy and image assets are reviewed."
-        />
+
+      {pinned ? (
+        <section className="mx-auto w-full max-w-5xl px-4 pt-12 sm:px-6 lg:px-8">
+          <FadeIn>
+            <PinnedPostCard post={pinned} />
+          </FadeIn>
+        </section>
+      ) : null}
+
+      <section className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+        <FadeIn>
+          <BlogTimeline posts={timelinePosts} />
+        </FadeIn>
       </section>
     </PageShell>
   );

--- a/src/components/cards/pinned-post-card.tsx
+++ b/src/components/cards/pinned-post-card.tsx
@@ -1,0 +1,65 @@
+import { ArrowUpRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { Badge } from "@/components/ui/badge";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import type { Post } from "@/content/schemas";
+
+interface PinnedPostCardProps {
+  post: Post;
+}
+
+/**
+ * One-per-site pinned essay slot at the top of /blog. Uses the
+ * display family for the title; otherwise reads the same data shape
+ * as PostListItem.
+ */
+export async function PinnedPostCard({ post }: PinnedPostCardProps) {
+  const t = await getTranslations("Blog");
+  const isDraft = post.status !== "ready";
+
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group relative grid gap-4 overflow-hidden rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:p-8"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-signal">
+          ★ {t("pinnedEyebrow")}
+        </span>
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+          {post.category}
+        </span>
+        {isDraft ? <DraftBadge label={post.status} /> : null}
+      </div>
+      <h3 className="font-[family-name:var(--font-display)] text-2xl font-semibold leading-tight text-balance sm:text-3xl">
+        {post.title}
+        <ArrowUpRight
+          aria-hidden="true"
+          className="ml-2 inline size-5 -translate-y-1 text-muted-foreground transition-transform duration-[var(--motion-fast)] group-hover:-translate-y-2 group-hover:translate-x-0.5 group-hover:text-foreground"
+        />
+      </h3>
+      <p className="max-w-2xl text-base leading-7 text-muted-foreground">
+        {post.excerpt}
+      </p>
+      <div className="flex flex-wrap items-center gap-3 pt-1">
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+          {post.date} · {post.readingTime}
+        </span>
+        {post.tags.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {post.tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant="outline"
+                className="text-[0.6rem] lowercase tracking-[0.1em]"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/cards/post-list-item.tsx
+++ b/src/components/cards/post-list-item.tsx
@@ -1,0 +1,74 @@
+import { ArrowUpRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+import type { Post } from "@/content/schemas";
+
+interface PostListItemProps {
+  post: Post;
+}
+
+const monoMeta =
+  "font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground";
+
+/**
+ * Single timeline row for /blog. The whole row is one Link — no
+ * nested interactive elements. Mono date column on md+, stacks on
+ * mobile. Hover lifts background subtly; no scale, no shadow.
+ */
+export function PostListItem({ post }: PostListItemProps) {
+  const isDraft = post.status !== "ready";
+  return (
+    <li>
+      <Link
+        href={`/blog/${post.slug}`}
+        className={cn(
+          "group grid gap-3 rounded-lg border border-transparent px-4 py-5 transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)]",
+          "hover:border-border hover:bg-muted/30",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "md:grid-cols-[8rem_1fr_auto] md:items-baseline md:gap-6",
+        )}
+      >
+        <span className={monoMeta}>{post.date}</span>
+        <div className="grid gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={monoMeta}>{post.category}</span>
+            {isDraft ? <DraftBadge label={post.status} /> : null}
+          </div>
+          <h3 className="text-lg font-semibold leading-snug text-foreground">
+            {post.title}
+            <ArrowUpRight
+              aria-hidden="true"
+              className="ml-1 inline size-4 -translate-y-0.5 text-muted-foreground transition-transform duration-[var(--motion-fast)] group-hover:-translate-y-1.5 group-hover:translate-x-0.5 group-hover:text-foreground"
+            />
+          </h3>
+          <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+            {post.excerpt}
+          </p>
+          {post.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {post.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className="text-[0.6rem] lowercase tracking-[0.1em]"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <span
+          className={cn(
+            monoMeta,
+            "shrink-0 md:text-right",
+          )}
+        >
+          {post.readingTime}
+        </span>
+      </Link>
+    </li>
+  );
+}

--- a/src/content/posts.ts
+++ b/src/content/posts.ts
@@ -1,6 +1,6 @@
-import { postSchema } from "./schemas";
+import { postsArraySchema } from "./schemas";
 
-export const posts = [
+export const posts = postsArraySchema.parse([
   {
     title: "Draft: Rebuilding M4rkyu.com as a black-and-white archive",
     slug: "rebuilding-m4rkyu-archive",
@@ -34,4 +34,4 @@ export const posts = [
     tags: ["games", "systems"],
     status: "placeholder",
   },
-].map((post) => postSchema.parse(post));
+]);

--- a/src/content/schemas.ts
+++ b/src/content/schemas.ts
@@ -125,6 +125,19 @@ export const postSchema = z.object({
   readingTime: z.string(),
   tags: z.array(z.string()),
   status: contentStatusSchema,
+  // Phase 1.5 additions
+  pinned: z.boolean().default(false),
+});
+
+// Build-time invariant: at most one post may be pinned site-wide.
+export const postsArraySchema = z.array(postSchema).superRefine((arr, ctx) => {
+  const pinnedCount = arr.filter((p) => p.pinned).length;
+  if (pinnedCount > 1) {
+    ctx.addIssue({
+      code: "custom",
+      message: `Only one post may be pinned at a time (found ${pinnedCount}).`,
+    });
+  }
 });
 
 export const gameSchema = z.object({


### PR DESCRIPTION
## Summary

Phase 1.5 of the m4rkyu.com redesign. Rewrites `/blog` from a 3-column
card grid into the timeline list specified in
[`docs/COMPONENT_MAP.md` §9](../blob/main/docs/COMPONENT_MAP.md). MDX
detail pages remain deferred (per planning round); list items link to
`/blog/[slug]` which gracefully renders the locale-aware 404 shipped
in Phase 1.

## What changed

### Schema (`src/content/schemas.ts`, `src/content/posts.ts`)
- `postSchema` gains optional `pinned: boolean` (defaults to `false`).
- New `postsArraySchema` with a `superRefine` enforcing the
  "at most one pinned post site-wide" invariant at parse time
  (matches the pattern in `docs/GALLERY_SOCIAL_SPEC.md` §10).
- `src/content/posts.ts` switched to the array-level parser so the
  invariant runs on every build / dev start.

### New components
- **`PostListItem`** (`src/components/cards/post-list-item.tsx`) —
  single timeline row. Mono date column on `md+`, the entire row is
  one `<Link>`, hover lifts background subtly. Re-uses `DraftBadge`
  for non-ready posts.
- **`PinnedPostCard`** (`src/components/cards/pinned-post-card.tsx`)
  — one-per-site pinned essay slot. Display family for the title,
  signal-tinted "Pinned" eyebrow with a small ★ marker.

### Page rewrite
- `src/app/[locale]/blog/page.tsx` — hero header → optional
  `PinnedPostCard` → `BlogTimeline`.
- `src/app/[locale]/blog/_client.tsx` (new) — wraps the functional
  tag filter and the `<ol>`/`<li>` timeline. Tags derived from
  `posts.flatMap`; URL state via `?tag=` param; "All" clears.

### i18n (`messages/{en,zh}.json`)
- New **`Blog`** namespace; CJK hand-translated.

## Phase 1 patterns applied
- All visible strings translated.
- `aria-hidden` on decorative icons.
- `aria-pressed` on tag chip buttons.
- Native semantic `<ol><li>` for the timeline. Single `<Link>` per
  row — no nested interactives.
- Tokens only.

## Test plan
- [ ] `/en/blog` and `/zh/blog` — timeline renders 3 placeholder
      rows; mono date column aligns on desktop; rows stack on
      mobile.
- [ ] Tag chip filter — clicking "remake" narrows the list; URL
      reflects `?tag=remake`; "All" clears.
- [ ] Set one post `pinned: true` in `posts.ts` (test only) →
      `PinnedPostCard` appears above the timeline. Set two pinned
      → build fails with "Only one post may be pinned at a time".
- [ ] Click any timeline row → navigates to `/blog/[slug]` →
      404 page (expected). Degrades cleanly.

## Out of scope
- MDX detail page (`/blog/[slug]`) — deferred per planning. Routes
  return 404 until real essays land.
- Drop-cap / TOC on detail page — Phase 2.x.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)