### PR TITLE
Phase 1.6 — Storybook coverage for case-study + Phase 1.2-1.5 components

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,6 @@
 import type { Preview } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import enMessages from "../messages/en.json";
 import "../src/app/globals.css";
 
 const preview: Preview = {
@@ -24,9 +26,11 @@ const preview: Preview = {
     (Story, context) => {
       const theme = (context.globals.theme as string) || "dark";
       return (
-        <div data-theme={theme} className="min-h-screen bg-background p-6 text-foreground">
-          <Story />
-        </div>
+        <NextIntlClientProvider locale="en" messages={enMessages}>
+          <div data-theme={theme} className="min-h-screen bg-background p-6 text-foreground">
+            <Story />
+          </div>
+        </NextIntlClientProvider>
       );
     },
   ],

--- a/src/components/cards/pinned-post-card.stories.tsx
+++ b/src/components/cards/pinned-post-card.stories.tsx
@@ -1,0 +1,87 @@
+// Visual approximation; the production component is async and reads getTranslations.
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ArrowUpRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import type { Post } from "@/content/schemas";
+
+function PinnedPostCardClone({ post }: { post: Post }) {
+  const isDraft = post.status !== "ready";
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group relative grid gap-4 overflow-hidden rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:p-8"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-signal">
+          ★ Pinned
+        </span>
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+          {post.category}
+        </span>
+        {isDraft ? <DraftBadge label={post.status} /> : null}
+      </div>
+      <h3 className="font-[family-name:var(--font-display)] text-2xl font-semibold leading-tight text-balance sm:text-3xl">
+        {post.title}
+        <ArrowUpRight
+          aria-hidden="true"
+          className="ml-2 inline size-5 -translate-y-1 text-muted-foreground transition-transform duration-[var(--motion-fast)] group-hover:-translate-y-2 group-hover:translate-x-0.5 group-hover:text-foreground"
+        />
+      </h3>
+      <p className="max-w-2xl text-base leading-7 text-muted-foreground">
+        {post.excerpt}
+      </p>
+      <div className="flex flex-wrap items-center gap-3 pt-1">
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+          {post.date} · {post.readingTime}
+        </span>
+        {post.tags.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {post.tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant="outline"
+                className="text-[0.6rem] lowercase tracking-[0.1em]"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </Link>
+  );
+}
+
+const samplePost: Post = {
+  title: "Field notes from the redesign archive",
+  slug: "field-notes-redesign-archive",
+  category: "Field notes",
+  excerpt:
+    "How the portfolio rebuild leans on a Zod content layer, owned UI primitives, and an editorial pace that resists feature creep.",
+  date: "2025-09-01",
+  readingTime: "7 min",
+  tags: ["nextjs", "process", "writing"],
+  status: "ready",
+  pinned: true,
+};
+
+const longTitlePost: Post = {
+  ...samplePost,
+  slug: "long-title-pinned-post",
+  title:
+    "A deliberately long pinned headline that wraps across multiple lines on desktop to verify the display family rhythm",
+};
+
+const meta = {
+  title: "cards/PinnedPostCard",
+  component: PinnedPostCardClone,
+} satisfies Meta<typeof PinnedPostCardClone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { post: samplePost } };
+export const LongTitle: Story = { args: { post: longTitlePost } };
+export const Draft: Story = { args: { post: { ...samplePost, status: "draft" } } };

--- a/src/components/cards/post-list-item.stories.tsx
+++ b/src/components/cards/post-list-item.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PostListItem } from "./post-list-item";
+import { posts } from "@/content/posts";
+import type { Post } from "@/content/schemas";
+
+const readyPost: Post = {
+  title: "Designing the redesign archive",
+  slug: "designing-the-redesign-archive",
+  category: "Process",
+  excerpt:
+    "Notes on porting the portfolio to Next.js, leaning on a Zod content layer, and keeping the editorial pace.",
+  date: "2025-08-12",
+  readingTime: "6 min",
+  tags: ["nextjs", "zod", "content"],
+  status: "ready",
+  pinned: false,
+};
+
+const longExcerptPost: Post = {
+  ...readyPost,
+  slug: "long-excerpt-post",
+  title: "Stress-testing the timeline row at desktop and mobile widths",
+  excerpt:
+    "An extended excerpt used to stress-test wrapping behaviour across the responsive timeline row. It should remain readable on mobile, fold cleanly under the title on small screens, and keep its mono date column aligned on the desktop layout without nudging the reading-time meta out of place.",
+};
+
+function PostListItemStory({ post }: { post: Post }) {
+  return (
+    <ol className="grid gap-1 divide-y divide-border/60 max-w-3xl">
+      <PostListItem post={post} />
+    </ol>
+  );
+}
+
+const meta = {
+  title: "cards/PostListItem",
+  component: PostListItemStory,
+} satisfies Meta<typeof PostListItemStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { post: posts[0] } };
+
+export const LongExcerpt: Story = { args: { post: longExcerptPost } };
+
+export const Ready: Story = { args: { post: readyPost } };

--- a/src/components/cards/resource-preview-card.stories.tsx
+++ b/src/components/cards/resource-preview-card.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ResourcePreviewCard } from "./resource-preview-card";
+import { resources } from "@/content/resources";
+import type { Resource } from "@/content/schemas";
+
+function ResourcePreviewCardStory({ resource }: { resource: Resource }) {
+  return (
+    <div className="mx-auto grid w-full max-w-sm">
+      <ResourcePreviewCard resource={resource} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "cards/ResourcePreviewCard",
+  component: ResourcePreviewCardStory,
+} satisfies Meta<typeof ResourcePreviewCardStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { resource: resources[0] },
+};
+
+const draftResource: Resource = {
+  name: "Storybook",
+  slug: "storybook",
+  category: "UI documentation",
+  description:
+    "Component workspace for visual states, accessibility checks, and design-system review.",
+  why: "Placeholder: expand stories as each final section component lands.",
+  link: "https://storybook.js.org",
+  pricing: "Free",
+  tags: ["components", "a11y", "documentation"],
+  status: "draft",
+};
+
+export const Draft: Story = {
+  args: { resource: draftResource },
+};

--- a/src/components/case-study/case-study-footer.stories.tsx
+++ b/src/components/case-study/case-study-footer.stories.tsx
@@ -1,0 +1,111 @@
+// Visual approximation; the production component is async and reads getTranslations.
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
+
+interface AdjacentEntry {
+  href: string;
+  title: string;
+  pitch: string;
+}
+
+interface FooterCloneProps {
+  prev?: AdjacentEntry;
+  next?: AdjacentEntry;
+  archiveHref: string;
+}
+
+function CaseStudyFooterClone({ prev, next, archiveHref }: FooterCloneProps) {
+  return (
+    <footer className="border-t bg-muted/20">
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid gap-6 lg:grid-cols-[1fr_auto_1fr]">
+          <Adjacent entry={prev} direction="prev" label="Previous" />
+          <div className="hidden lg:block lg:self-center">
+            <Button asChild variant="outline">
+              <Link href={archiveHref}>Back to archive</Link>
+            </Button>
+          </div>
+          <Adjacent entry={next} direction="next" label="Next" />
+        </div>
+        <div className="mt-8 flex justify-center lg:hidden">
+          <Button asChild variant="outline">
+            <Link href={archiveHref}>Back to archive</Link>
+          </Button>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function Adjacent({
+  entry,
+  direction,
+  label,
+}: {
+  entry: AdjacentEntry | undefined;
+  direction: "prev" | "next";
+  label: string;
+}) {
+  if (!entry) {
+    return <div className="hidden lg:block" aria-hidden="true" />;
+  }
+  const isNext = direction === "next";
+  return (
+    <Link
+      href={entry.href}
+      className={`group flex flex-col gap-2 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+        isNext ? "lg:text-right" : ""
+      }`}
+    >
+      <span
+        className={`flex items-center gap-1.5 font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground ${
+          isNext ? "lg:justify-end" : ""
+        }`}
+      >
+        {!isNext ? <ArrowLeft aria-hidden="true" className="size-3" /> : null}
+        {label}
+        {isNext ? <ArrowRight aria-hidden="true" className="size-3" /> : null}
+      </span>
+      <span className="text-lg font-semibold leading-snug">{entry.title}</span>
+      <span className="line-clamp-2 text-sm leading-6 text-muted-foreground">
+        {entry.pitch}
+      </span>
+    </Link>
+  );
+}
+
+const prevEntry: AdjacentEntry = {
+  href: "/projects/nimbus",
+  title: "Nimbus",
+  pitch:
+    "A secure file management platform shaped around calm organization, OTP access, and storage analytics.",
+};
+
+const nextEntry: AdjacentEntry = {
+  href: "/projects/m4rketview",
+  title: "M4rketView",
+  pitch:
+    "A cryptocurrency screener built for quick scanning, watchlist thinking, and market table clarity.",
+};
+
+const meta = {
+  title: "case-study/CaseStudyFooter",
+  component: CaseStudyFooterClone,
+} satisfies Meta<typeof CaseStudyFooterClone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BothSides: Story = {
+  args: { prev: prevEntry, next: nextEntry, archiveHref: "/projects" },
+};
+
+export const OnlyPrev: Story = {
+  args: { prev: prevEntry, next: undefined, archiveHref: "/projects" },
+};
+
+export const OnlyNext: Story = {
+  args: { prev: undefined, next: nextEntry, archiveHref: "/projects" },
+};

--- a/src/components/case-study/case-study-header.stories.tsx
+++ b/src/components/case-study/case-study-header.stories.tsx
@@ -1,0 +1,113 @@
+// Visual approximation; the production component is async and reads getTranslations.
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ArrowUpRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import { allProjects } from "@/content/projects";
+import type { Project } from "@/content/schemas";
+
+function CaseStudyHeaderClone({ project }: { project: Project }) {
+  return (
+    <section className="relative overflow-hidden border-b">
+      <div className="absolute inset-0 bg-cyber-grid opacity-30" aria-hidden="true" />
+      <div className="archive-vignette absolute inset-0" aria-hidden="true" />
+      <div className="relative mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <Link
+          href="/projects"
+          className="font-mono text-[0.7rem] uppercase tracking-[0.24em] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          ← Back to projects
+        </Link>
+        <div className="mt-10 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{project.category}</Badge>
+          <span className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+            {project.year}
+          </span>
+          <Badge variant={project.status === "ready" ? "success" : "outline"}>
+            {project.status}
+          </Badge>
+          {project.contentStatus !== "ready" ? (
+            <DraftBadge label={project.contentStatus} />
+          ) : null}
+        </div>
+        <h1 className="mt-6 max-w-5xl text-balance font-[family-name:var(--font-display)] text-[clamp(2.5rem,6vw,5.5rem)] font-semibold leading-[0.95] tracking-tight">
+          {project.title}
+        </h1>
+        <p className="mt-7 max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {project.shortPitch}
+        </p>
+        <dl className="mt-10 grid gap-6 border-t pt-6 sm:grid-cols-[auto_1fr] sm:gap-x-10">
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            Role
+          </dt>
+          <dd className="text-sm leading-7 text-foreground">{project.role}</dd>
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            Stack
+          </dt>
+          <dd className="flex flex-wrap gap-1.5">
+            {project.stack.map((item) => (
+              <Badge key={item} variant="outline" className="text-[0.65rem]">
+                {item}
+              </Badge>
+            ))}
+          </dd>
+          {project.liveUrl || project.githubUrl ? (
+            <>
+              <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                Links
+              </dt>
+              <dd className="flex flex-wrap gap-2">
+                {project.liveUrl ? (
+                  <Button asChild size="sm">
+                    <a
+                      href={project.liveUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Live
+                      <ArrowUpRight aria-hidden="true" className="size-3.5" />
+                    </a>
+                  </Button>
+                ) : null}
+                {project.githubUrl ? (
+                  <Button asChild size="sm" variant="outline">
+                    <a
+                      href={project.githubUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Source
+                    </a>
+                  </Button>
+                ) : null}
+              </dd>
+            </>
+          ) : null}
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+const meta = {
+  title: "case-study/CaseStudyHeader",
+  component: CaseStudyHeaderClone,
+} satisfies Meta<typeof CaseStudyHeaderClone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProductionProject: Story = { args: { project: allProjects[0] } };
+
+export const DraftProject: Story = {
+  args: {
+    project: {
+      ...allProjects[0],
+      title: "Placeholder case study",
+      contentStatus: "draft",
+      status: "draft",
+    },
+  },
+};

--- a/src/components/case-study/case-study-section.stories.tsx
+++ b/src/components/case-study/case-study-section.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CaseStudyList, CaseStudySection } from "./case-study-section";
+
+interface SectionStoryArgs {
+  eyebrow?: string;
+  title: string;
+  body?: string;
+  items?: string[];
+  numbered?: boolean;
+}
+
+function CaseStudySectionStory({
+  eyebrow,
+  title,
+  body,
+  items,
+  numbered,
+}: SectionStoryArgs) {
+  return (
+    <CaseStudySection eyebrow={eyebrow} title={title}>
+      {body ? <p>{body}</p> : null}
+      {items ? (
+        <CaseStudyList
+          className="mt-5"
+          items={items}
+          numbered={numbered}
+        />
+      ) : null}
+    </CaseStudySection>
+  );
+}
+
+const meta = {
+  title: "case-study/CaseStudySection",
+  component: CaseStudySectionStory,
+} satisfies Meta<typeof CaseStudySectionStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    eyebrow: "01 · Problem",
+    title: "Personal cloud tools either feel too bare or too opaque",
+    body: "The case study unpacks how Nimbus reframes the storage interface as an operating surface — uploads, access, and usage signals presented at a calm, readable density.",
+  },
+};
+
+export const WithBulletList: Story = {
+  args: {
+    eyebrow: "Architecture",
+    title: "Boundaries the case study leans on",
+    items: [
+      "Server-rendered routes keep the dashboard shell quick to parse.",
+      "Client interactivity is scoped to upload state, charts, and account actions.",
+      "Storage primitives stay abstracted away from the visible product surface.",
+    ],
+  },
+};
+
+export const WithNumberedList: Story = {
+  args: {
+    eyebrow: "Process",
+    title: "Three moves that shaped the redesign",
+    items: [
+      "Audit the existing Vite portfolio for content debt before moving any files.",
+      "Stand up the Zod-backed content layer first, then route components onto it.",
+      "Layer in editorial typography only after the structural work is calm.",
+    ],
+    numbered: true,
+  },
+};

--- a/src/components/case-study/game-detail-header.stories.tsx
+++ b/src/components/case-study/game-detail-header.stories.tsx
@@ -1,0 +1,123 @@
+// Visual approximation; the production component is async and reads getTranslations.
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ArrowUpRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { Link } from "@/i18n/navigation";
+import type { Game } from "@/content/schemas";
+
+function GameDetailHeaderClone({ game }: { game: Game }) {
+  return (
+    <section className="relative overflow-hidden border-b">
+      <div className="absolute inset-0 bg-cyber-grid opacity-30" aria-hidden="true" />
+      <div className="archive-vignette absolute inset-0" aria-hidden="true" />
+      <div className="relative mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <Link
+          href="/games"
+          className="font-mono text-[0.7rem] uppercase tracking-[0.24em] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          ← games
+        </Link>
+        <div className="mt-10 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{game.engine}</Badge>
+          <span className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+            {game.year}
+          </span>
+          {game.status !== "ready" ? <DraftBadge label={game.status} /> : null}
+        </div>
+        <h1 className="mt-6 max-w-5xl text-balance font-[family-name:var(--font-display)] text-[clamp(2.5rem,6vw,5.5rem)] font-semibold leading-[0.95] tracking-tight">
+          {game.title}
+        </h1>
+        <p className="mt-7 max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          {game.pitch}
+        </p>
+        <dl className="mt-10 grid gap-6 border-t pt-6 sm:grid-cols-[auto_1fr] sm:gap-x-10">
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            Role
+          </dt>
+          <dd className="text-sm leading-7 text-foreground">{game.role}</dd>
+          {game.platforms.length > 0 ? (
+            <>
+              <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                Platforms
+              </dt>
+              <dd className="flex flex-wrap gap-1.5">
+                {game.platforms.map((item) => (
+                  <Badge key={item} variant="outline" className="text-[0.65rem]">
+                    {item}
+                  </Badge>
+                ))}
+              </dd>
+            </>
+          ) : null}
+          {game.buildLinks.length > 0 ? (
+            <>
+              <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                Links
+              </dt>
+              <dd className="flex flex-wrap gap-2">
+                {game.buildLinks.map((link, index) => (
+                  <Button
+                    key={`${index}-${link.url}`}
+                    asChild
+                    size="sm"
+                    variant={index === 0 ? "default" : "outline"}
+                  >
+                    <a href={link.url} target="_blank" rel="noopener noreferrer">
+                      {link.label}
+                      <ArrowUpRight aria-hidden="true" className="size-3.5" />
+                    </a>
+                  </Button>
+                ))}
+              </dd>
+            </>
+          ) : null}
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+const defaultGame: Game = {
+  title: "Signal Drift",
+  slug: "signal-drift",
+  engine: "Unity",
+  year: "2025",
+  status: "draft",
+  pitch:
+    "A short atmospheric prototype exploring traversal, ambient signal cues, and minimal UI in a quiet cyber-grid.",
+  role: "Solo design, programming, and audio direction.",
+  notes: [],
+  platforms: ["WebGL", "Windows"],
+  pillars: [],
+  buildLinks: [
+    { label: "Play WebGL", url: "https://example.com/signal-drift/webgl" },
+    { label: "Download Win", url: "https://example.com/signal-drift/win" },
+  ],
+};
+
+const minimalGame: Game = {
+  title: "Untitled prototype",
+  slug: "untitled-prototype",
+  engine: "Godot",
+  year: "TBD",
+  status: "placeholder",
+  pitch: "Placeholder: replace with the final pitch once the prototype lands.",
+  role: "TBD: scope and ownership pending.",
+  notes: [],
+  platforms: [],
+  pillars: [],
+  buildLinks: [],
+};
+
+const meta = {
+  title: "case-study/GameDetailHeader",
+  component: GameDetailHeaderClone,
+} satisfies Meta<typeof GameDetailHeaderClone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { game: defaultGame } };
+export const Minimal: Story = { args: { game: minimalGame } };

--- a/src/components/case-study/pull-quote-block.stories.tsx
+++ b/src/components/case-study/pull-quote-block.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PullQuoteBlock } from "./pull-quote-block";
+
+const meta = {
+  title: "case-study/PullQuoteBlock",
+  component: PullQuoteBlock,
+  args: {
+    quote:
+      "Authentication copy matters as much as authentication mechanics — readers feel the difference before they notice it.",
+  },
+} satisfies Meta<typeof PullQuoteBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    eyebrow: "Outcome",
+  },
+};
+
+export const WithAttribution: Story = {
+  args: {
+    eyebrow: "Lessons learned",
+    attribution: "Nimbus case study, 2025",
+  },
+};

--- a/src/components/sections/closing-cta-strip.stories.tsx
+++ b/src/components/sections/closing-cta-strip.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ClosingCTAStrip } from "./closing-cta-strip";
+
+const meta = {
+  title: "sections/ClosingCTAStrip",
+  component: ClosingCTAStrip,
+  args: {
+    statement:
+      "Looking for an engineer who treats portfolio surfaces like product surfaces.",
+    primary: { label: "View projects", href: "/projects" },
+  },
+} satisfies Meta<typeof ClosingCTAStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithMailto: Story = {
+  args: {
+    secondary: { label: "Email me", mailto: "hello@example.com" },
+  },
+};
+
+export const WithSecondaryHref: Story = {
+  args: {
+    secondary: { label: "Visit portal", href: "/portal" },
+  },
+};

--- a/src/components/ui/magic/blur-fade.stories.tsx
+++ b/src/components/ui/magic/blur-fade.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { BlurFade } from "./blur-fade";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface BlurFadeStoryArgs {
+  delay?: number;
+}
+
+function BlurFadeStory({ delay }: BlurFadeStoryArgs) {
+  return (
+    <BlurFade delay={delay} className="mx-auto w-full max-w-md">
+      <Card>
+        <CardHeader>
+          <CardTitle>BlurFade demo</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm leading-6 text-muted-foreground">
+          The wrapper fades and de-blurs once the element enters the viewport.
+          Reload the story or scroll the canvas to retrigger the animation.
+        </CardContent>
+      </Card>
+    </BlurFade>
+  );
+}
+
+const meta = {
+  title: "ui/magic/BlurFade",
+  component: BlurFadeStory,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Honors prefers-reduced-motion via useReducedMotion() — short-circuits to a static div.",
+      },
+    },
+  },
+} satisfies Meta<typeof BlurFadeStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Delayed: Story = {
+  args: { delay: 0.4 },
+};


### PR DESCRIPTION
## Summary

Phase 1.6 of the m4rkyu.com redesign. Documents the visual primitives
shipped in Phases 1.1–1.5 in Storybook so future contributors can
review states without running the full app. Pure documentation phase —
no runtime code changes.

## What changed

### `.storybook/preview.tsx`
- Wraps every story in a `NextIntlClientProvider locale=\"en\"` loaded
  from `messages/en.json`. Existing stories were translation-free so
  they remain unaffected; future stories that use `useTranslations`
  now work without per-story setup.

### 10 new story files

**Sync components — used directly:**
- `cards/post-list-item.stories.tsx` — `Default` / `LongExcerpt` / `Ready`.
- `cards/resource-preview-card.stories.tsx` — `Default` / `Draft`.
- `case-study/case-study-section.stories.tsx` — `Default` /
  `WithBulletList` / `WithNumberedList` (covers `CaseStudySection` +
  `CaseStudyList`).
- `case-study/pull-quote-block.stories.tsx` — `Default` /
  `WithAttribution`.
- `sections/closing-cta-strip.stories.tsx` — `WithMailto` /
  `WithSecondaryHref`.
- `ui/magic/blur-fade.stories.tsx` — `Default` / `Delayed`; reduced-
  motion note hoisted to component-level docs.

**Async server components — visual approximation wrappers:**
The production components are `async` + read `getTranslations`, which
Storybook can't render directly. Each story file ships a small sync
visual clone with literal English strings, prefaced with a 1-line
comment: \`// Visual approximation; the production component is async
and reads getTranslations.\`. Wrapper class names are copied verbatim
from production so the visual stays byte-identical.

- `cards/pinned-post-card.stories.tsx` — `Default` / `LongTitle` /
  `Draft`.
- `case-study/case-study-header.stories.tsx` — `ProductionProject` /
  `DraftProject`.
- `case-study/case-study-footer.stories.tsx` — `BothSides` /
  `OnlyPrev` / `OnlyNext`.
- `case-study/game-detail-header.stories.tsx` — `Default` /
  `Minimal`.

## Phase 1 patterns applied
- All visible strings localized in production code; story wrappers use
  literal English (clearly marked story-only).
- No `bg-zinc-*` / hex / ad-hoc shadows; tokens only.
- No new dependencies.
- Type-only imports for `Meta` / `StoryObj`.

## Test plan
- [ ] `npm run storybook` locally — every story renders without
      console errors.
- [ ] `npm run build-storybook` — succeeds (verify on a non-Windows
      box if available).
- [ ] Addon-a11y panel shows zero violations on each story.
- [ ] Theme toolbar (dark / light / monochrome) flips correctly across
      all stories.

## Out of scope
- Production async server components rendered natively in Storybook
  via experimental RSC support — defer until @storybook/nextjs-vite's
  RSC support stabilizes; the wrapper pattern works today.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)