### PR TITLE
Phase 1.7 — Cmd-K command palette

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -196,5 +196,22 @@
     "comingSoon": "Coming soon",
     "readMore": "Read more",
     "status": "Status"
+  },
+  "CommandPalette": {
+    "title": "Command palette",
+    "description": "Jump to a page, frame, or setting.",
+    "trigger": "Search…",
+    "searchPlaceholder": "Search pages, frames, settings…",
+    "pagesGroup": "Pages",
+    "recentGroup": "Recent frames",
+    "settingsGroup": "Settings",
+    "themeLight": "Light theme",
+    "themeDark": "Dark theme",
+    "themeMono": "Monochrome theme",
+    "toggleLocale": "Switch language",
+    "noResults": "No matches.",
+    "hintNavigate": "Navigate",
+    "hintSelect": "Select",
+    "hintClose": "Close"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -196,5 +196,22 @@
     "comingSoon": "即将开放",
     "readMore": "继续阅读",
     "status": "状态"
+  },
+  "CommandPalette": {
+    "title": "命令面板",
+    "description": "快速跳转到页面、影像或设置。",
+    "trigger": "搜索…",
+    "searchPlaceholder": "搜索页面、影像或设置…",
+    "pagesGroup": "页面",
+    "recentGroup": "最近影像",
+    "settingsGroup": "设置",
+    "themeLight": "亮色主题",
+    "themeDark": "暗色主题",
+    "themeMono": "黑白主题",
+    "toggleLocale": "切换语言",
+    "noResults": "没有匹配项。",
+    "hintNavigate": "导航",
+    "hintSelect": "选择",
+    "hintClose": "关闭"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lenis": "^1.3.23",
         "lucide-react": "^1.14.0",
         "motion": "^12.38.0",
@@ -5873,6 +5874,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/collapse-white-space": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lenis": "^1.3.23",
     "lucide-react": "^1.14.0",
     "motion": "^12.38.0",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { ThemeProvider } from "@/components/theme/theme-provider";
+import { CommandPaletteProvider } from "@/components/system/command-palette-provider";
 import { routing, type Locale } from "@/i18n/routing";
 
 export function generateStaticParams() {
@@ -25,7 +26,9 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <ThemeProvider>{children}</ThemeProvider>
+      <ThemeProvider>
+        <CommandPaletteProvider>{children}</CommandPaletteProvider>
+      </ThemeProvider>
     </NextIntlClientProvider>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,6 +3,7 @@ import { Link } from "@/i18n/navigation";
 import type { Locale } from "@/i18n/routing";
 import { ThemeSwitcher } from "@/components/theme/theme-switcher";
 import { LanguageSwitcher } from "@/components/system/language-switcher";
+import { CommandPaletteTrigger } from "@/components/system/command-palette-trigger";
 import { NavLink } from "./nav-link";
 import { MobileNav } from "./mobile-nav";
 
@@ -39,6 +40,7 @@ export async function Header({ locale }: { locale: Locale }) {
         </nav>
 
         <div className="hidden items-center gap-2 xl:flex">
+          <CommandPaletteTrigger />
           <ThemeSwitcher />
           <LanguageSwitcher />
           <Link

--- a/src/components/system/command-palette-provider.tsx
+++ b/src/components/system/command-palette-provider.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { CommandPalette } from "./command-palette";
+
+interface CommandPaletteContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(
+  null,
+);
+
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) {
+    throw new Error(
+      "useCommandPalette must be used inside <CommandPaletteProvider>",
+    );
+  }
+  return ctx;
+}
+
+export function CommandPaletteProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = useCallback(() => setOpen((value) => !value), []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.repeat || event.defaultPrevented) return;
+      if (
+        event.key.toLowerCase() === "k" &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggle();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggle]);
+
+  const value = useMemo(
+    () => ({ open, setOpen, toggle }),
+    [open, toggle],
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+      <CommandPalette open={open} onOpenChange={setOpen} />
+    </CommandPaletteContext.Provider>
+  );
+}

--- a/src/components/system/command-palette-trigger.tsx
+++ b/src/components/system/command-palette-trigger.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCommandPalette } from "./command-palette-provider";
+
+/**
+ * Visual entry point to the Cmd-K palette. Sits in the header rail.
+ * Keyboard users can also open via Cmd/Ctrl-K from anywhere — the
+ * provider owns the global keydown listener.
+ */
+export function CommandPaletteTrigger() {
+  const { setOpen } = useCommandPalette();
+  const t = useTranslations("CommandPalette");
+
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      aria-label={t("title")}
+      className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background/70 px-3 text-xs text-muted-foreground transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <Search aria-hidden="true" className="size-3.5" />
+      <span>{t("trigger")}</span>
+      <kbd className="ml-2 rounded border bg-muted px-1.5 py-0.5 font-mono text-[0.6rem] uppercase tracking-[0.18em]">
+        ⌘K
+      </kbd>
+    </button>
+  );
+}

--- a/src/components/system/command-palette.tsx
+++ b/src/components/system/command-palette.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Briefcase,
+  Camera,
+  CircleDot,
+  FileText,
+  Gamepad2,
+  Image as ImageIcon,
+  Languages,
+  Layers,
+  Mail,
+  Moon,
+  Sun,
+  Terminal,
+  User,
+  Wrench,
+} from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { useTheme } from "next-themes";
+import { usePathname } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { useRouter } from "@/i18n/navigation";
+import type { Locale } from "@/i18n/routing";
+import { galleryItems } from "@/content/gallery";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const PAGES: { key: string; href: string; icon: typeof Briefcase }[] = [
+  { key: "projects", href: "/projects", icon: Briefcase },
+  { key: "games", href: "/games", icon: Gamepad2 },
+  { key: "gallery", href: "/gallery", icon: Camera },
+  { key: "blog", href: "/blog", icon: FileText },
+  { key: "media", href: "/media", icon: ImageIcon },
+  { key: "resources", href: "/resources", icon: Wrench },
+  { key: "about", href: "/about", icon: User },
+  { key: "contact", href: "/contact", icon: Mail },
+  { key: "portal", href: "/portal", icon: Terminal },
+];
+
+const THEMES = [
+  { value: "light", icon: Sun, key: "themeLight" },
+  { value: "dark", icon: Moon, key: "themeDark" },
+  { value: "monochrome", icon: CircleDot, key: "themeMono" },
+] as const;
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const tNav = useTranslations("Navigation");
+  const tPalette = useTranslations("CommandPalette");
+  const router = useRouter();
+  const pathname = usePathname();
+  const locale = useLocale() as Locale;
+  const { setTheme } = useTheme();
+
+  const recentFrames = useMemo(
+    () =>
+      galleryItems
+        .filter((item) => item.status === "ready")
+        .slice(0, 6),
+    [],
+  );
+
+  function go(href: string) {
+    onOpenChange(false);
+    router.push(href);
+  }
+
+  function pickTheme(value: string) {
+    setTheme(value);
+    onOpenChange(false);
+  }
+
+  function pickLocale(nextLocale: Locale) {
+    if (nextLocale === locale) {
+      onOpenChange(false);
+      return;
+    }
+    onOpenChange(false);
+    const rest = pathname.replace(/^\/(en|zh)/, "") || "/";
+    router.replace(rest, { locale: nextLocale });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        hideCloseButton
+        className="max-w-xl gap-0 overflow-hidden p-0"
+      >
+        <VisuallyHidden>
+          <DialogTitle>{tPalette("title")}</DialogTitle>
+          <DialogDescription>{tPalette("description")}</DialogDescription>
+        </VisuallyHidden>
+        <Command label={tPalette("title")} className="rounded-md">
+          <CommandInput placeholder={tPalette("searchPlaceholder")} />
+          <CommandList>
+            <CommandEmpty>{tPalette("noResults")}</CommandEmpty>
+
+            <CommandGroup heading={tPalette("pagesGroup")}>
+              {PAGES.map((page) => {
+                const Icon = page.icon;
+                return (
+                  <CommandItem
+                    key={page.href}
+                    value={`${tNav(page.key)} ${page.key}`}
+                    onSelect={() => go(page.href)}
+                  >
+                    <Icon
+                      aria-hidden="true"
+                      className="size-4 text-muted-foreground"
+                    />
+                    <span>{tNav(page.key)}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+
+            {recentFrames.length > 0 ? (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading={tPalette("recentGroup")}>
+                  {recentFrames.map((item) => (
+                    <CommandItem
+                      key={item.slug}
+                      value={`${item.title} ${item.collection} ${item.tags.join(" ")}`}
+                      onSelect={() => go(`/gallery?frame=${item.slug}`)}
+                    >
+                      <Layers
+                        aria-hidden="true"
+                        className="size-4 text-muted-foreground"
+                      />
+                      <span className="truncate">{item.title}</span>
+                      <span className="ml-auto truncate font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground">
+                        {item.collection}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            ) : null}
+
+            <CommandSeparator />
+
+            <CommandGroup heading={tPalette("settingsGroup")}>
+              {THEMES.map((entry) => {
+                const Icon = entry.icon;
+                return (
+                  <CommandItem
+                    key={entry.value}
+                    value={`theme ${entry.value} ${tPalette(entry.key)}`}
+                    onSelect={() => pickTheme(entry.value)}
+                  >
+                    <Icon
+                      aria-hidden="true"
+                      className="size-4 text-muted-foreground"
+                    />
+                    <span>{tPalette(entry.key)}</span>
+                  </CommandItem>
+                );
+              })}
+              <CommandItem
+                value={`language ${locale === "en" ? "中文" : "English"}`}
+                onSelect={() => pickLocale(locale === "en" ? "zh" : "en")}
+              >
+                <Languages
+                  aria-hidden="true"
+                  className="size-4 text-muted-foreground"
+                />
+                <span>{tPalette("toggleLocale")}</span>
+                <span className="ml-auto font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground">
+                  {locale === "en" ? "中文" : "EN"}
+                </span>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+
+          <div className="flex items-center justify-end gap-2 border-t px-3 py-2 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground">
+            <span>{tPalette("hintNavigate")}</span>
+            <kbd className="rounded border px-1.5 py-0.5">↑↓</kbd>
+            <span>{tPalette("hintSelect")}</span>
+            <kbd className="rounded border px-1.5 py-0.5">↵</kbd>
+            <span>{tPalette("hintClose")}</span>
+            <kbd className="rounded border px-1.5 py-0.5">esc</kbd>
+          </div>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// Adapted from cmdk · phase 1.7 redesign
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+Command.displayName = "Command";
+
+export const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center gap-2 border-b px-3" cmdk-input-wrapper="">
+    <Search aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = "CommandInput";
+
+export const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn(
+      "max-h-[60vh] overflow-y-auto overflow-x-hidden p-1",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandList.displayName = "CommandList";
+
+export const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm text-muted-foreground"
+    {...props}
+  />
+));
+CommandEmpty.displayName = "CommandEmpty";
+
+export const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground",
+      "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-mono [&_[cmdk-group-heading]]:text-[0.6rem] [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.22em] [&_[cmdk-group-heading]]:text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandGroup.displayName = "CommandGroup";
+
+export const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("mx-2 h-px bg-border", className)}
+    {...props}
+  />
+));
+CommandSeparator.displayName = "CommandSeparator";
+
+export const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-sm outline-none transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)]",
+      "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground",
+      "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = "CommandItem";
+
+export function CommandShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn(
+        "ml-auto font-mono text-[0.6rem] uppercase tracking-[0.22em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -8,11 +8,17 @@ export const Dialog = DialogPrimitive.Root;
 export const DialogTrigger = DialogPrimitive.Trigger;
 export const DialogClose = DialogPrimitive.Close;
 
+interface DialogContentProps
+  extends React.ComponentProps<typeof DialogPrimitive.Content> {
+  hideCloseButton?: boolean;
+}
+
 export function DialogContent({
   className,
   children,
+  hideCloseButton,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: DialogContentProps) {
   return (
     <DialogPrimitive.Portal>
       <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" />
@@ -24,10 +30,12 @@ export function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
-          <X className="size-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {hideCloseButton ? null : (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <X className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPrimitive.Portal>
   );


### PR DESCRIPTION
## Summary

Phase 1.7 of the m4rkyu.com redesign — the final polish phase in the
planned round (1.3–1.7). Adds a Cmd-K / Ctrl-K command palette to
every page. Adds **the only new runtime dep across the entire round**:
`cmdk@^1.1.1` (~20 KB gz).

## What changed

### `src/components/ui/command.tsx` (NEW)
Tokenized shadcn-style copy-in adapter for `cmdk`. Exports `Command`,
`CommandInput`, `CommandList`, `CommandEmpty`, `CommandGroup`,
`CommandSeparator`, `CommandItem`, `CommandShortcut`. Header comment
marks the source. Surface uses `bg-popover` /
`text-popover-foreground`; selected items use `bg-accent` /
`text-accent-foreground`. All transitions through `--motion-fast` /
`--ease-premium`.

### `src/components/system/command-palette-provider.tsx` (NEW)
Owns palette open/close state via context. The global Cmd/Ctrl-K
keydown listener lives here, with `event.repeat` /
`event.defaultPrevented` guards and case-insensitive `k` matching.

### `src/components/system/command-palette.tsx` (NEW)
Wraps the `Command` primitive inside a Radix `Dialog` (with the new
`hideCloseButton` prop so the X doesn't overlap the search input).
Three groups:
- **Pages** — mirrors header `navItems`. Indexed by both translated
  label and stable key so en + zh users find routes via either string.
- **Recent frames** — last 6 ready gallery items.
- **Settings** — light / dark / monochrome theme toggles and an
  en↔zh locale flip that preserves the current path. (Kernel theme
  intentionally not surfaced — per design direction it stays an
  easter egg.)

### `src/components/system/command-palette-trigger.tsx` (NEW)
Search-pill button with `<kbd>⌘K</kbd>` mounted in the header right
rail at `xl+`. The keyboard shortcut works globally regardless.

### `src/components/ui/dialog.tsx`
Adds an opt-in `hideCloseButton` prop. Backward compatible with
existing consumers — defaults to showing the X.

### `src/app/[locale]/layout.tsx` + `src/components/layout/header.tsx`
- Layout wraps children in `<CommandPaletteProvider>`.
- Header drops the trigger into the existing right rail next to
  `ThemeSwitcher` / `LanguageSwitcher` / Portal CTA.

### `messages/{en,zh}.json`
New `CommandPalette` namespace; CJK hand-translated.

## Phase 1 patterns applied
- All visible strings translated.
- `aria-hidden=\"true\"` on every decorative icon.
- Tokens only.
- Existing primitive (`DialogContent`) gained an opt-in prop rather
  than being rewritten — backward compatible.

## Test plan
- [ ] Press `Cmd-K` (Mac) / `Ctrl-K` (Win) on any page → palette opens.
- [ ] Type \"gal\" → filters to Gallery + recent gallery frames.
      Arrow-down + Enter navigates.
- [ ] Type \"light\" / \"亮\" → theme toggles surface.
- [ ] Type \"中文\" while on `/en` → locale toggle item appears;
      Enter switches to `/zh/...`.
- [ ] Tab into the search-pill button → opens palette via space/enter.
- [ ] `prefers-reduced-motion` → palette opens with no animation
      (`cmdk` doesn't animate; we don't add any).
- [ ] Mobile: palette opens as a centered modal (sheet variant
      deferred to future phase if needed).

## Out of scope (future phases)
- Mobile bottom-sheet variant.
- Locale-strip regex extraction (duplicated in `LanguageSwitcher`).
- Platform-aware `Cmd` vs `Ctrl` glyph in the trigger pill.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)