### PR TITLE
polish: hierarchy, mobile, a11y for Phase 1.3–1.7 surfaces

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -21,7 +21,7 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
         <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_0.8fr] lg:px-8">
           <FadeIn>
-            <SectionHeading title={t("title")} description={t("intro")} />
+            <SectionHeading as="h1" title={t("title")} description={t("intro")} />
           </FadeIn>
           <FadeIn direction="left" delay={0.1}>
             <PlaceholderImage label="PORTRAIT OR STUDIO IMAGE TBD" aspect="aspect-[4/5]" />

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -40,6 +40,7 @@ export default async function BlogPage({
         <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <FadeIn>
             <SectionHeading
+              as="h1"
               eyebrow={t("eyebrow")}
               title={t("title")}
               description={t("description")}

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -18,6 +18,7 @@ export default async function ContactPage({ params }: { params: Promise<{ locale
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
         <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <SectionHeading
+            as="h1"
             eyebrow="collaboration"
             title="Contact"
             description="A production-safe project inquiry flow with a mailto fallback now, ready for a server-side form provider later."

--- a/src/app/[locale]/gallery/[collection]/page.tsx
+++ b/src/app/[locale]/gallery/[collection]/page.tsx
@@ -28,7 +28,7 @@ export default async function GalleryCollectionPage({
   return (
     <PageShell locale={locale}>
       <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-        <SectionHeading eyebrow="collection" title={item.title} description={item.description} />
+        <SectionHeading as="h1" eyebrow="collection" title={item.title} description={item.description} />
         <div className="mt-8 flex flex-wrap gap-2">
           <Badge variant="outline">{item.count} planned frames</Badge>
           <Badge variant="warning">{item.status}</Badge>

--- a/src/app/[locale]/gallery/page.tsx
+++ b/src/app/[locale]/gallery/page.tsx
@@ -18,6 +18,7 @@ export default async function GalleryPage({ params }: { params: Promise<{ locale
         <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <FadeIn>
             <SectionHeading
+              as="h1"
               eyebrow="visual archive"
               title="Gallery"
               description="Black-and-white photography, digital art, and contact sheets. Placeholder frames hold the structure while final media is optimised."

--- a/src/app/[locale]/gallery/saved/page.tsx
+++ b/src/app/[locale]/gallery/saved/page.tsx
@@ -42,6 +42,7 @@ export default function SavedGalleryPage({
         <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <FadeIn>
             <SectionHeading
+              as="h1"
               eyebrow={t("savedEyebrow")}
               title={t("saved")}
               description={t("savedDescription")}

--- a/src/app/[locale]/games/page.tsx
+++ b/src/app/[locale]/games/page.tsx
@@ -43,6 +43,7 @@ export default async function GamesPage({
         <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_22rem] lg:px-8">
           <FadeIn>
             <SectionHeading
+              as="h1"
               eyebrow={tGame("eyebrow")}
               title={tNav("games")}
               description={tGame("intro")}

--- a/src/app/[locale]/media/page.tsx
+++ b/src/app/[locale]/media/page.tsx
@@ -24,6 +24,7 @@ export default async function MediaPage({ params }: { params: Promise<{ locale: 
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
         <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_0.9fr] lg:px-8">
           <SectionHeading
+            as="h1"
             eyebrow="video / process"
             title="Media"
             description="A lightweight media archive layout with still posters and no autoplay. Final clips, posters, and captions can replace the placeholder frames later."

--- a/src/app/[locale]/projects/_client.tsx
+++ b/src/app/[locale]/projects/_client.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search } from "lucide-react";
+import { ChevronDown, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { ProjectCard } from "@/components/cards/project-card";
 import { Badge } from "@/components/ui/badge";
@@ -235,18 +235,10 @@ export function ProjectsClient({
                 {t("draftsCount", { count: drafts.length })}
               </span>
             </span>
-            <span
+            <ChevronDown
               aria-hidden="true"
-              className="font-mono text-xs text-muted-foreground group-open:hidden"
-            >
-              +
-            </span>
-            <span
-              aria-hidden="true"
-              className="hidden font-mono text-xs text-muted-foreground group-open:inline"
-            >
-              −
-            </span>
+              className="size-4 shrink-0 text-muted-foreground transition-transform duration-[var(--motion-fast)] ease-[var(--ease-premium)] group-open:rotate-180"
+            />
           </summary>
           <div className="border-t p-5">
             <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -40,6 +40,7 @@ export default async function ProjectsPage({
         <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_22rem] lg:px-8">
           <FadeIn>
             <SectionHeading
+              as="h1"
               eyebrow="work index"
               title={t("title")}
               description={t("intro")}

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -16,6 +16,7 @@ export default async function ResourcesPage({ params }: { params: Promise<{ loca
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
         <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
           <SectionHeading
+            as="h1"
             eyebrow="tool library"
             title="Resources"
             description="A searchable reference-library prototype. Placeholder entries are explicitly marked and can later be indexed with Pagefind."

--- a/src/app/[locale]/tools/page.tsx
+++ b/src/app/[locale]/tools/page.tsx
@@ -17,6 +17,7 @@ export default async function ToolsPage({ params }: { params: Promise<{ locale: 
     <PageShell locale={locale}>
       <section className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <SectionHeading
+          as="h1"
           eyebrow="utility index"
           title="Tools"
           description="Placeholder utility directory for small tools, implementation notes, and creative systems. Final tool pages can be added without changing the shell."

--- a/src/components/cards/pinned-post-card.tsx
+++ b/src/components/cards/pinned-post-card.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, Star } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/placeholders/draft-badge";
@@ -24,8 +24,9 @@ export async function PinnedPostCard({ post }: PinnedPostCardProps) {
       className="group relative grid gap-4 overflow-hidden rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:p-8"
     >
       <div className="flex flex-wrap items-center gap-2">
-        <span className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-signal">
-          ★ {t("pinnedEyebrow")}
+        <span className="inline-flex items-center gap-1.5 font-mono text-[0.65rem] uppercase tracking-[0.24em] text-signal">
+          <Star aria-hidden="true" className="size-3 fill-current" />
+          {t("pinnedEyebrow")}
         </span>
         <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
           {post.category}

--- a/src/components/cards/post-list-item.tsx
+++ b/src/components/cards/post-list-item.tsx
@@ -14,8 +14,9 @@ const monoMeta =
 
 /**
  * Single timeline row for /blog. The whole row is one Link — no
- * nested interactive elements. Mono date column on md+, stacks on
- * mobile. Hover lifts background subtly; no scale, no shadow.
+ * nested interactive elements. Mono date column on md+; on mobile,
+ * date and reading time co-locate on a single meta line above the
+ * title. Hover lifts background subtly; no scale, no shadow.
  */
 export function PostListItem({ post }: PostListItemProps) {
   const isDraft = post.status !== "ready";
@@ -30,7 +31,23 @@ export function PostListItem({ post }: PostListItemProps) {
           "md:grid-cols-[8rem_1fr_auto] md:items-baseline md:gap-6",
         )}
       >
-        <span className={monoMeta}>{post.date}</span>
+        {/* Mobile-only meta line: date · reading time */}
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-x-3 gap-y-1",
+            "md:hidden",
+          )}
+        >
+          <span className={monoMeta}>{post.date}</span>
+          <span aria-hidden="true" className="text-muted-foreground/40">
+            ·
+          </span>
+          <span className={monoMeta}>{post.readingTime}</span>
+        </div>
+
+        {/* Desktop-only: standalone date column */}
+        <span className={cn(monoMeta, "hidden md:inline")}>{post.date}</span>
+
         <div className="grid gap-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className={monoMeta}>{post.category}</span>
@@ -60,12 +77,9 @@ export function PostListItem({ post }: PostListItemProps) {
             </div>
           ) : null}
         </div>
-        <span
-          className={cn(
-            monoMeta,
-            "shrink-0 md:text-right",
-          )}
-        >
+
+        {/* Desktop-only: reading time, right-aligned */}
+        <span className={cn(monoMeta, "hidden shrink-0 md:inline md:text-right")}>
           {post.readingTime}
         </span>
       </Link>

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Menu } from "lucide-react";
+import { Menu, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetHeader,
   SheetTitle,
@@ -14,6 +15,7 @@ import { Link } from "@/i18n/navigation";
 import type { Locale } from "@/i18n/routing";
 import { LanguageSwitcher } from "@/components/system/language-switcher";
 import { ThemeSwitcher } from "@/components/theme/theme-switcher";
+import { useCommandPalette } from "@/components/system/command-palette-provider";
 
 const navItems = [
   ["projects", "/projects"],
@@ -29,19 +31,38 @@ const navItems = [
 
 export function MobileNav({ locale }: { locale: Locale }) {
   const t = useTranslations("Navigation");
+  const tPalette = useTranslations("CommandPalette");
+  const { setOpen: setPaletteOpen } = useCommandPalette();
 
   return (
     <Sheet>
       <SheetTrigger asChild>
         <Button variant="outline" size="icon" className="xl:hidden" aria-label={t("menu")}>
-          <Menu className="size-4" />
+          <Menu aria-hidden="true" className="size-4" />
         </Button>
       </SheetTrigger>
       <SheetContent className="top-0 h-dvh translate-y-0 sm:max-w-sm">
         <SheetHeader>
           <SheetTitle>M4rkyu.com</SheetTitle>
         </SheetHeader>
-        <nav aria-label="Mobile navigation" className="mt-8 grid gap-3">
+
+        <SheetClose asChild>
+          <button
+            type="button"
+            onClick={() => {
+              // Sheet close fires before this; defer palette open to next tick
+              // so focus management doesn't fight.
+              window.setTimeout(() => setPaletteOpen(true), 0);
+            }}
+            className="mt-6 inline-flex h-10 w-full items-center gap-2 rounded-md border border-border bg-background/70 px-3 text-sm text-muted-foreground transition-colors duration-[var(--motion-fast)] ease-[var(--ease-premium)] hover:border-ring/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            aria-label={tPalette("title")}
+          >
+            <Search aria-hidden="true" className="size-4" />
+            <span>{tPalette("trigger")}</span>
+          </button>
+        </SheetClose>
+
+        <nav aria-label="Mobile navigation" className="mt-6 grid gap-3">
           {navItems.map(([key, href]) => (
             <Link
               key={key}

--- a/src/components/sections/section-heading.tsx
+++ b/src/components/sections/section-heading.tsx
@@ -1,10 +1,26 @@
 interface SectionHeadingProps {
-  eyebrow?: string
-  title: string
-  description?: string
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  /**
+   * Heading level. Defaults to `h2`. Use `h1` when this is the page's
+   * top-level title (most archive pages — /projects, /games, /blog, etc.).
+   * Detail pages should keep this as `h2` because they own their own
+   * `h1` via `CaseStudyHeader` / `GameDetailHeader`.
+   */
+  as?: "h1" | "h2";
 }
 
-export function SectionHeading({ eyebrow, title, description }: SectionHeadingProps) {
+const headingClass =
+  "mt-3 text-3xl font-[700] leading-[1.05] tracking-normal text-balance sm:text-4xl lg:text-5xl";
+
+export function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  as = "h2",
+}: SectionHeadingProps) {
+  const Heading = as;
   return (
     <div className="max-w-3xl">
       {eyebrow ? (
@@ -12,14 +28,12 @@ export function SectionHeading({ eyebrow, title, description }: SectionHeadingPr
           {eyebrow}
         </p>
       ) : null}
-      <h2 className="mt-3 text-3xl font-[700] leading-[1.05] tracking-normal text-balance sm:text-4xl lg:text-5xl">
-        {title}
-      </h2>
+      <Heading className={headingClass}>{title}</Heading>
       {description ? (
         <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
           {description}
         </p>
       ) : null}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary

Targeted polish pass after the round of redesign PRs (1.3–1.7) merged
to main. Five focused changes; no business logic touched, no new deps.

## What changed

### 1. Heading hierarchy (a11y) — real `<h1>` on every archive page
- `SectionHeading` gains an `as: \"h1\" | \"h2\"` prop, defaults to
  `h2` (backward compatible).
- Eleven pages now pass `as=\"h1\"` so they render a proper top-level
  heading: `/blog`, `/projects`, `/games`, `/gallery`,
  `/gallery/saved`, `/gallery/[collection]`, `/media`, `/resources`,
  `/tools`, `/contact`, `/about`.
- Detail pages (`/projects/[slug]`, `/games/[slug]`) keep their
  dedicated `<h1>` inside `CaseStudyHeader` / `GameDetailHeader`;
  their `SectionHeading` usage stays `h2`.

### 2. `PostListItem` mobile layout
- On `<md`, date and reading time co-locate on a single mono meta
  line above the title (separated by a quiet `·` divider).
- On `md+`, the original three-column grid is preserved.
- Net effect: meta no longer orphaned at the bottom of the row on
  phones.

### 3. Cmd-K reachable on mobile
- `MobileNav` surfaces a \"Search…\" pill at the top of the sheet
  that closes the sheet and opens the command palette via the
  existing `useCommandPalette()` context. Uses `setTimeout(0)` so
  the sheet's focus restoration finishes before the palette mounts.

### 4. Projects drafts collapsible chevron
- Replaces the `+` / `−` unicode glyphs with a lucide `ChevronDown`
  that rotates 180° via `group-open:rotate-180`. Reads as part of
  the system rather than a one-off glyph.

### 5. `PinnedPostCard` star glyph
- Replaces the `★` unicode character with a lucide `Star`
  (`size-3 fill-current`) for icon-family consistency.

## Phase 1 patterns preserved
- Tokens only — no `bg-zinc-*`, no hex.
- aria-hidden on every decorative icon.
- No new packages.
- All existing translations / locales unchanged.

## Test plan
- [ ] Lighthouse a11y on `/blog`, `/projects`, `/games`, `/gallery`
      → no \"missing h1\" warning.
- [ ] `/blog` on 360px → date + reading time on one line above
      title; tap area covers the full row.
- [ ] Open mobile sheet → tap \"Search…\" → sheet closes, palette
      opens.
- [ ] `/projects` → drafts `<details>` chevron rotates on toggle;
      respects `prefers-reduced-motion`.
- [ ] Set a post `pinned: true` locally → `★` is the lucide Star
      icon, signal-tinted.

## Out of scope
- Tailwind 4 canonical-class sweep (e.g. `duration-[var(--motion-fast)]`
  → `duration-(--motion-fast)`, `aspect-[4/5]` → `aspect-4/5`). The
  warnings exist repo-wide and deserve a dedicated sweep PR rather
  than half-done in this polish PR.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)