### PR TITLE
Phase 2.1 — AnimatedGridPattern on homepage hero

### DIFF
--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl"
 import { ArrowRight, Code } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Marquee } from "@/components/ui/marquee"
+import { AnimatedGridPattern } from "@/components/ui/magic/animated-grid-pattern"
 import { Link } from "@/i18n/navigation"
 import type { Locale } from "@/i18n/routing"
 
@@ -44,7 +45,13 @@ export function HeroSection({ locale }: { locale: Locale }) {
   return (
     <section className="relative overflow-hidden border-b">
       {/* atmospheric layers */}
-      <div className="absolute inset-0 bg-cyber-grid opacity-40" aria-hidden="true" />
+      <AnimatedGridPattern
+        numSquares={28}
+        maxOpacity={0.18}
+        duration={5}
+        repeatDelay={0.8}
+        className="text-foreground/40"
+      />
       <div className="noise-layer absolute inset-0" aria-hidden="true" />
       <div className="scanline-layer absolute inset-0 opacity-35" aria-hidden="true" />
 

--- a/src/components/ui/magic/animated-grid-pattern.stories.tsx
+++ b/src/components/ui/magic/animated-grid-pattern.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { AnimatedGridPattern } from "./animated-grid-pattern";
+
+function AnimatedGridPatternStory(args: {
+  numSquares?: number;
+  maxOpacity?: number;
+  duration?: number;
+}) {
+  return (
+    <div className="relative h-[400px] w-full overflow-hidden rounded-md border bg-background">
+      <AnimatedGridPattern
+        numSquares={args.numSquares}
+        maxOpacity={args.maxOpacity}
+        duration={args.duration}
+        className="text-foreground/40"
+      />
+      <div className="relative grid h-full place-items-center">
+        <p className="font-mono text-xs uppercase tracking-[0.22em] text-muted-foreground">
+          Hover-friendly demo surface
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: "ui/magic/AnimatedGridPattern",
+  component: AnimatedGridPatternStory,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Honors prefers-reduced-motion via useReducedMotion() — short-circuits to a fixed-opacity grid with a small subset of cells highlighted statically.",
+      },
+    },
+  },
+} satisfies Meta<typeof AnimatedGridPatternStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { numSquares: 28, maxOpacity: 0.18, duration: 5 },
+};
+
+export const Dense: Story = {
+  args: { numSquares: 60, maxOpacity: 0.25, duration: 4 },
+};
+
+export const Quiet: Story = {
+  args: { numSquares: 16, maxOpacity: 0.12, duration: 6 },
+};

--- a/src/components/ui/magic/animated-grid-pattern.tsx
+++ b/src/components/ui/magic/animated-grid-pattern.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+// Adapted from Magic UI · AnimatedGridPattern · sprint-2 phase 2.1
+
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface AnimatedGridPatternProps {
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  strokeDasharray?: string | number;
+  numSquares?: number;
+  className?: string;
+  maxOpacity?: number;
+  duration?: number;
+  repeatDelay?: number;
+}
+
+interface Square {
+  id: number;
+  pos: [number, number];
+}
+
+/**
+ * Animated SVG grid that gently fades random cells in and out. Designed
+ * to be the homepage hero ambient layer (replaces `bg-cyber-grid` on
+ * that one section). The static rest state still reads as a hairline
+ * grid so motion-reduced visitors don't lose the texture.
+ *
+ * Performance notes:
+ * - `numSquares` defaults to 30 per docs/UI_LIBRARY_STRATEGY.md §11.
+ * - All animation is on opacity only (cheap on the GPU).
+ * - `useReducedMotion()` short-circuits to a static grid.
+ */
+export function AnimatedGridPattern({
+  width = 56,
+  height = 56,
+  x = -1,
+  y = -1,
+  strokeDasharray = 0,
+  numSquares = 30,
+  className,
+  maxOpacity = 0.3,
+  duration = 4,
+  repeatDelay = 0.5,
+}: AnimatedGridPatternProps) {
+  const id = useId();
+  const containerRef = useRef<SVGSVGElement>(null);
+  const dimensionsRef = useRef({ width: 0, height: 0 });
+  const reduceMotion = useReducedMotion();
+  const [squares, setSquares] = useState<Square[]>([]);
+
+  function generateSquares(count: number, w: number, h: number): Square[] {
+    if (w === 0 || h === 0) return [];
+    return Array.from({ length: count }, (_, i) => ({
+      id: i,
+      pos: [
+        Math.floor((Math.random() * w) / width),
+        Math.floor((Math.random() * h) / height),
+      ],
+    }));
+  }
+
+  // Single effect: resize observer regenerates squares whenever the
+  // container dimensions actually change (event-driven, not a chained
+  // setState in render).
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const node = containerRef.current;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width: w, height: h } = entry.contentRect;
+        if (w === dimensionsRef.current.width && h === dimensionsRef.current.height) {
+          continue;
+        }
+        dimensionsRef.current = { width: w, height: h };
+        setSquares(generateSquares(numSquares, w, h));
+      }
+    });
+    resizeObserver.observe(node);
+    return () => resizeObserver.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [numSquares, width, height]);
+
+  // Static cells used in reduced-motion mode — first N positions, no
+  // animation, low fixed opacity so the texture is still readable.
+  const staticSquares = useMemo<Square[]>(
+    () => squares.slice(0, Math.min(squares.length, 12)),
+    [squares],
+  );
+
+  return (
+    <svg
+      ref={containerRef}
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-0 h-full w-full fill-current text-foreground/9 stroke-current",
+        className,
+      )}
+    >
+      <defs>
+        <pattern
+          id={id}
+          width={width}
+          height={height}
+          patternUnits="userSpaceOnUse"
+          x={x}
+          y={y}
+        >
+          <path
+            d={`M.5 ${height}V.5H${width}`}
+            fill="none"
+            strokeDasharray={strokeDasharray}
+          />
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${id})`} />
+      <svg x={x} y={y} className="overflow-visible">
+        {(reduceMotion ? staticSquares : squares).map(({ pos: [px, py], id: squareId }, index) => {
+          if (reduceMotion) {
+            return (
+              <rect
+                key={`${squareId}-${index}`}
+                width={width - 1}
+                height={height - 1}
+                x={px * width + 1}
+                y={py * height + 1}
+                fill="currentColor"
+                fillOpacity={maxOpacity * 0.6}
+                strokeWidth="0"
+              />
+            );
+          }
+          return (
+            <motion.rect
+              key={`${squareId}-${index}`}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: maxOpacity }}
+              // Cubic-bezier mirrors --ease-premium; motion's transition.ease cannot read CSS variables.
+              transition={{
+                duration,
+                repeat: Infinity,
+                delay: (index * 0.1) % duration,
+                repeatType: "reverse",
+                repeatDelay,
+                ease: [0.2, 0.7, 0.2, 1],
+              }}
+              onAnimationComplete={() => {
+                setSquares((current) => {
+                  if (!current[index]) return current;
+                  const { width: w, height: h } = dimensionsRef.current;
+                  if (w === 0 || h === 0) return current;
+                  const next = [...current];
+                  next[index] = {
+                    id: current[index].id + 1,
+                    pos: [
+                      Math.floor((Math.random() * w) / width),
+                      Math.floor((Math.random() * h) / height),
+                    ],
+                  };
+                  return next;
+                });
+              }}
+              width={width - 1}
+              height={height - 1}
+              x={px * width + 1}
+              y={py * height + 1}
+              fill="currentColor"
+              strokeWidth="0"
+            />
+          );
+        })}
+      </svg>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint 2, Phase 2.1. Adds the second Magic UI primitive of the
redesign (after `BlurFade` in Phase 1.2): an animated SVG grid that
gently fades random cells in and out behind the homepage hero.

## What changed

### `src/components/ui/magic/animated-grid-pattern.tsx` (NEW)
- Tokenized copy-in: `text-foreground` for stroke, no hardcoded
  colors, no neon. Same comment header style as `BlurFade`.
- **Honors `prefers-reduced-motion`** via `useReducedMotion()` —
  short-circuits to a static grid with a small subset of cells
  fixed at 60% of `maxOpacity`. Texture preserved, animation off.
- Single `useEffect` with `ResizeObserver`; squares regenerated
  only on actual dimension change. State-in-effect lint rule
  respected by driving `setSquares` from the resize callback.
- Hardcoded easing carve-out commented inline (motion's
  `transition.ease` cannot read CSS variables — same carve-out as
  `BlurFade`).

### `src/components/sections/hero-section.tsx`
- Replaces `<div className=\"absolute inset-0 bg-cyber-grid opacity-40\" />`
  with `<AnimatedGridPattern numSquares={28} maxOpacity={0.18} ... />`.
- `numSquares` clamped to 28 (perf rule §11: ≤ 30); `maxOpacity`
  0.18 so the hero still reads as terminal precision, not
  animation showcase.
- Every other use of `bg-cyber-grid` across the site keeps the
  static class.

### `src/components/ui/magic/animated-grid-pattern.stories.tsx` (NEW)
- `Default` (production config), `Dense` (60 squares), `Quiet` (16
  squares).

## Phase 2 cross-cutting rules
- Tokens only.
- Storybook story in the same PR.
- One atmospheric layer per viewport — `AnimatedGridPattern` is
  behind hero only.
- No new runtime deps (`motion/react` already present).

## Test plan
- [ ] Visit `/en` and `/zh` — hero ambient is animated; rest of
      page unchanged.
- [ ] DevTools → enable `prefers-reduced-motion` → animation
      stops; texture still readable.
- [ ] Lighthouse mobile perf ≥ 90 (no degradation vs main).
- [ ] Storybook → all 3 stories render; addon-a11y zero
      violations.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)