### PR TITLE
Phase 2.3 — BorderBeam on first featured project card (closes Sprint 2)

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -109,9 +109,13 @@ export default async function HomePage({
           </div>
         </FadeIn>
         <Stagger className="mt-10 grid gap-5 md:grid-cols-3" delay={0.1}>
-          {featuredProjects.slice(0, 3).map((project) => (
+          {featuredProjects.slice(0, 3).map((project, index) => (
             <StaggerItem key={project.slug}>
-              <ProjectCard project={project} locale={locale} />
+              <ProjectCard
+                project={project}
+                locale={locale}
+                highlighted={index === 0}
+              />
             </StaggerItem>
           ))}
         </Stagger>

--- a/src/components/cards/project-card.tsx
+++ b/src/components/cards/project-card.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { BorderBeam } from "@/components/ui/magic/border-beam"
 import { DraftBadge } from "@/components/placeholders/draft-badge"
 import { PlaceholderImage } from "@/components/placeholders/placeholder-image"
 import { Link } from "@/i18n/navigation"
@@ -16,7 +17,19 @@ import type { Project } from "@/content/schemas"
 
 const ease = [0.2, 0.7, 0.2, 1] as const
 
-export function ProjectCard({ project, locale }: { project: Project; locale: Locale }) {
+interface ProjectCardProps {
+  project: Project
+  locale: Locale
+  /**
+   * Wraps the card with a BorderBeam highlight. Use sparingly —
+   * `docs/UI_LIBRARY_STRATEGY.md` §9 forbids more than one beam in
+   * view at once. Currently used on the FIRST featured card on the
+   * homepage only.
+   */
+  highlighted?: boolean
+}
+
+export function ProjectCard({ project, locale, highlighted = false }: ProjectCardProps) {
   const t = useTranslations("Projects")
   const localized = localize(project, locale)
   const cover = project.screenshots[0]
@@ -29,9 +42,10 @@ export function ProjectCard({ project, locale }: { project: Project; locale: Loc
     <motion.div
       whileHover={{ y: -5 }}
       transition={{ duration: 0.22, ease }}
-      className="h-full"
+      className="relative h-full"
     >
-      <Card className="group h-full overflow-hidden bg-card/80 transition-[border-color,box-shadow] duration-300 hover:border-ring/50 hover:shadow-lg">
+      {highlighted ? <BorderBeam duration={14} borderRadius={8} /> : null}
+      <Card className="group relative h-full overflow-hidden bg-card/80 transition-[border-color,box-shadow] duration-300 hover:border-ring/50 hover:shadow-lg">
         <div className="relative aspect-[16/10] overflow-hidden border-b bg-muted">
           {cover ? (
             <Image

--- a/src/components/ui/magic/border-beam.stories.tsx
+++ b/src/components/ui/magic/border-beam.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { BorderBeam } from "./border-beam";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface BorderBeamStoryArgs {
+  duration?: number;
+  delay?: number;
+  borderRadius?: number;
+}
+
+function BorderBeamStory(args: BorderBeamStoryArgs) {
+  return (
+    <div className="relative mx-auto h-full max-w-sm">
+      <BorderBeam {...args} />
+      <Card className="bg-card/80">
+        <CardHeader>
+          <CardTitle>BorderBeam demo</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm leading-6 text-muted-foreground">
+          A quiet light trace runs around the border. One per page only —
+          the host sets a positioned wrapper; the beam fills the space
+          via `pointer-events: none`.
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+const meta = {
+  title: "ui/magic/BorderBeam",
+  component: BorderBeamStory,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Honors prefers-reduced-motion via useReducedMotion() — returns null so the host card is identical to non-highlighted siblings.",
+      },
+    },
+  },
+} satisfies Meta<typeof BorderBeamStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { duration: 14, borderRadius: 8 },
+};
+
+export const Slow: Story = {
+  args: { duration: 22, borderRadius: 8 },
+};
+
+export const Delayed: Story = {
+  args: { duration: 14, delay: 1.2, borderRadius: 8 },
+};

--- a/src/components/ui/magic/border-beam.tsx
+++ b/src/components/ui/magic/border-beam.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+// Adapted from Magic UI · BorderBeam · sprint-2 phase 2.3
+
+import { motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface BorderBeamProps {
+  className?: string;
+  size?: number;
+  duration?: number;
+  delay?: number;
+  /**
+   * Beam color at peak. Defaults to `var(--ring)` so the trace
+   * stays in the brand cyan.
+   */
+  colorFrom?: string;
+  /**
+   * Tail color (transparent by default for a quiet light trace
+   * rather than a solid neon ring).
+   */
+  colorTo?: string;
+  /** CSS border radius for the beam mask, in px. */
+  borderRadius?: number;
+  /** CSS border width for the beam, in px. */
+  borderWidth?: number;
+}
+
+/**
+ * Quiet light trace that runs around a card's border. Designed to
+ * highlight a SINGLE element on a page (per docs/UI_LIBRARY_STRATEGY.md
+ * §9 — "more than one BorderBeam in view at once is banned").
+ *
+ * Honors prefers-reduced-motion: returns nothing, so the host card
+ * looks identical to its non-highlighted siblings.
+ */
+export function BorderBeam({
+  className,
+  size = 200,
+  duration = 12,
+  delay = 0,
+  colorFrom = "var(--ring)",
+  colorTo = "transparent",
+  borderRadius = 8,
+  borderWidth = 1.5,
+}: BorderBeamProps) {
+  const reduceMotion = useReducedMotion();
+  if (reduceMotion) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden",
+        className,
+      )}
+      style={{ borderRadius }}
+    >
+      <motion.div
+        className="absolute"
+        style={{
+          width: size,
+          aspectRatio: "1 / 1",
+          background: `conic-gradient(from 0deg at 50% 50%, ${colorTo} 0deg, ${colorFrom} 60deg, ${colorTo} 120deg)`,
+          maskImage: `linear-gradient(transparent calc(50% - ${borderWidth}px), black 50%, transparent calc(50% + ${borderWidth}px))`,
+          WebkitMaskImage: `linear-gradient(transparent calc(50% - ${borderWidth}px), black 50%, transparent calc(50% + ${borderWidth}px))`,
+          offsetPath: `rect(0 100% 100% 0 round ${borderRadius}px)`,
+          offsetDistance: "0%",
+        }}
+        initial={{ offsetDistance: "0%" }}
+        animate={{ offsetDistance: "100%" }}
+        // Cubic-bezier mirrors --ease-premium; motion's transition.ease cannot read CSS variables.
+        transition={{
+          duration,
+          delay,
+          repeat: Infinity,
+          ease: [0.2, 0.7, 0.2, 1],
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes Sprint 2 — atmosphere wave. Adds the fourth Magic UI primitive
(after `BlurFade` in Phase 1.2 and `AnimatedGridPattern` /
`BentoGrid` in Phase 2.1 / 2.2): a quiet light trace that runs
around a single card's border.

Per `docs/UI_LIBRARY_STRATEGY.md` §9, only **one** BorderBeam may be
in view at any time. This PR uses it on the first featured project
card on the homepage and nowhere else.

## What changed

### `src/components/ui/magic/border-beam.tsx` (NEW)
- Tokenized copy-in. Beam color defaults to `var(--ring)`; tail is
  transparent so the effect reads as a light trace, not a neon
  ring.
- **Honors `prefers-reduced-motion`** via `useReducedMotion()` —
  returns `null` entirely, so the host card looks identical to
  non-highlighted siblings.
- Pure CSS `conic-gradient` masked through a horizontal mask so
  only a thin band shows; motion drives `offsetDistance` to walk
  the gradient around the rounded-rect border.
- `aria-hidden` + `pointer-events-none` — never interferes with
  the card's interactive surface or focus ring.

### `src/components/cards/project-card.tsx`
- New optional `highlighted: boolean` prop. When `true`, mounts
  `<BorderBeam>` inside the motion wrapper before the `<Card>`.
  Default `false` — every other consumer (projects archive, 404
  page, related-work links) gets no beam.

### `src/app/[locale]/page.tsx`
- Passes `highlighted={index === 0}` to the first card in the
  featured-projects `Stagger`. The other two stay vanilla so the
  comparison reads visually.

### `src/components/ui/magic/border-beam.stories.tsx` (NEW)
- `Default` / `Slow` / `Delayed`.

## Sprint 2 — atmosphere wave summary

| Phase | What | PR |
|---|---|---|
| 2.1 | `AnimatedGridPattern` on homepage hero | #20 |
| 2.2 | `BentoGrid` on homepage gallery preview | #21 |
| 2.3 | `BorderBeam` on first featured project card | this PR |

- Zero new runtime deps across the sprint (Magic UI is copy-in;
  depends only on `motion/react` already present).
- Every primitive honors `prefers-reduced-motion` and ships with a
  Storybook story in the same PR.
- One atmospheric layer per viewport rule respected:
  `AnimatedGridPattern` behind hero only; bento has no background
  pattern; one `BorderBeam` per page.

## Test plan
- [ ] `/en` — first project card shows a quiet beam tracing the
      border. Cards 2 and 3 are static.
- [ ] `prefers-reduced-motion` enabled → beam disabled, all three
      cards look identical.
- [ ] Card focus ring still readable (beam has
      `pointer-events: none`).
- [ ] `/projects` archive does NOT highlight any card.
- [ ] Beam color reads as cyan on both `light` and `dark` themes.
      If too neon on light, drop opacity in a follow-up via
      `color-mix`.
- [ ] Storybook → all 3 stories render.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)