### PR TITLE
Phase 3.2 — gameSchema translations parity + plumbed localize()

### DIFF
--- a/src/app/[locale]/games/[slug]/page.tsx
+++ b/src/app/[locale]/games/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { PullQuoteBlock } from "@/components/case-study/pull-quote-block";
 import { CaseStudyFooter } from "@/components/case-study/case-study-footer";
 import { games } from "@/content/games";
 import type { Locale } from "@/i18n/routing";
+import { localize } from "@/lib/content/localize";
 
 export function generateStaticParams() {
   return games.flatMap((game) => [
@@ -30,9 +31,10 @@ export async function generateMetadata({
   const { locale, slug } = await params;
   const game = games.find((item) => item.slug === slug);
   if (!game) return {};
+  const localized = localize(game, locale);
   return {
-    title: game.title,
-    description: game.pitch,
+    title: localized.title,
+    description: localized.pitch as string,
     alternates: { canonical: `/${locale}/games/${slug}` },
   };
 }
@@ -48,6 +50,7 @@ export default async function GameDetailPage({
 
   const tGame = await getTranslations({ locale, namespace: "Game" });
   const tCase = await getTranslations({ locale, namespace: "CaseStudy" });
+  const localized = localize(game, locale);
 
   // Adjacent navigation in archive order — predictable, no clever sort.
   const gameIndex = games.findIndex((g) => g.slug === game.slug);
@@ -55,24 +58,35 @@ export default async function GameDetailPage({
   const nextGame =
     gameIndex < games.length - 1 ? games[gameIndex + 1] : undefined;
   const prev = prevGame
-    ? {
-        href: `/games/${prevGame.slug}`,
-        title: prevGame.title,
-        pitch: prevGame.pitch,
-      }
+    ? (() => {
+        const localizedPrev = localize(prevGame, locale);
+        return {
+          href: `/games/${prevGame.slug}`,
+          title: localizedPrev.title,
+          pitch: localizedPrev.pitch as string,
+        };
+      })()
     : undefined;
   const next = nextGame
-    ? {
-        href: `/games/${nextGame.slug}`,
-        title: nextGame.title,
-        pitch: nextGame.pitch,
-      }
+    ? (() => {
+        const localizedNext = localize(nextGame, locale);
+        return {
+          href: `/games/${nextGame.slug}`,
+          title: localizedNext.title,
+          pitch: localizedNext.pitch as string,
+        };
+      })()
     : undefined;
 
   return (
     <PageShell locale={locale}>
       <article>
-        <GameDetailHeader game={game} />
+        <GameDetailHeader
+          game={game}
+          title={localized.title}
+          pitch={localized.pitch as string}
+          role={localized.role as string}
+        />
 
         <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
           <BlurFade>
@@ -117,7 +131,7 @@ export default async function GameDetailPage({
             <BlurFade>
               <PullQuoteBlock
                 eyebrow={tCase("outcomeEyebrow")}
-                quote={game.outcome}
+                quote={(localized.outcome as string | undefined) ?? game.outcome}
               />
             </BlurFade>
           </section>
@@ -130,7 +144,7 @@ export default async function GameDetailPage({
                 eyebrow={tGame("postmortemEyebrow")}
                 title={tGame("postmortemTitle")}
               >
-                <p>{game.postmortem}</p>
+                <p>{(localized.postmortem as string | undefined) ?? game.postmortem}</p>
               </CaseStudySection>
             </BlurFade>
           </section>

--- a/src/app/[locale]/games/page.tsx
+++ b/src/app/[locale]/games/page.tsx
@@ -8,6 +8,7 @@ import { FadeIn } from "@/components/motion/fade-in";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { games } from "@/content/games";
 import type { Locale } from "@/i18n/routing";
+import { localize } from "@/lib/content/localize";
 
 export async function generateMetadata({
   params,
@@ -72,19 +73,22 @@ export default async function GamesPage({
 
       <section className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 lg:px-8">
         <Stagger className="grid gap-5 md:grid-cols-2 lg:grid-cols-3" delay={0.05}>
-          {games.map((game) => (
-            <StaggerItem key={game.slug}>
-              <ArchiveCard
-                title={game.title}
-                description={game.pitch}
-                eyebrow={game.engine}
-                status={game.status}
-                href={`/games/${game.slug}`}
-                locale={locale}
-                mediaLabel={tGame("coverTbd")}
-              />
-            </StaggerItem>
-          ))}
+          {games.map((game) => {
+            const localized = localize(game, locale);
+            return (
+              <StaggerItem key={game.slug}>
+                <ArchiveCard
+                  title={localized.title}
+                  description={localized.pitch as string}
+                  eyebrow={game.engine}
+                  status={game.status}
+                  href={`/games/${game.slug}`}
+                  locale={locale}
+                  mediaLabel={tGame("coverTbd")}
+                />
+              </StaggerItem>
+            );
+          })}
         </Stagger>
       </section>
     </PageShell>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -29,6 +29,7 @@ import { posts } from "@/content/posts";
 import { games } from "@/content/games";
 import { mediaItems } from "@/content/media";
 import { profile } from "@/content/profile";
+import { localize } from "@/lib/content/localize";
 
 export default async function HomePage({
   params,
@@ -39,13 +40,16 @@ export default async function HomePage({
   const t = await getTranslations({ locale, namespace: "Home" });
 
   // Status pulse — real data only. Skips slots when no honest source exists.
+  // Each entry is localized so /zh reads in CJK when the underlying content
+  // has a `translations.zh` slice; falls back to the base fields otherwise.
   const statusEntries: StatusPulseEntry[] = [];
   const shipping = featuredProjects.find((p) => p.contentStatus === "ready");
   if (shipping) {
+    const localizedShipping = localize(shipping, locale);
     statusEntries.push({
       kind: "shipping",
-      label: shipping.title,
-      detail: shipping.shortPitch,
+      label: localizedShipping.title,
+      detail: localizedShipping.shortPitch as string,
       href: `/projects/${shipping.slug}`,
     });
   }
@@ -60,10 +64,11 @@ export default async function HomePage({
   }
   const now = games.find((g) => g.status !== "ready") ?? games[0];
   if (now) {
+    const localizedNow = localize(now, locale);
     statusEntries.push({
       kind: "now",
-      label: now.title,
-      detail: now.pitch,
+      label: localizedNow.title,
+      detail: localizedNow.pitch as string,
       href: `/games/${now.slug}`,
     });
   }

--- a/src/components/case-study/game-detail-header.tsx
+++ b/src/components/case-study/game-detail-header.tsx
@@ -8,6 +8,14 @@ import type { Game } from "@/content/schemas";
 
 interface GameDetailHeaderProps {
   game: Game;
+  /**
+   * Localized fields. Pass values from `localize(game, locale)` so the
+   * header reads in the active locale when `game.translations[locale]`
+   * is set; falls back to the base game fields otherwise.
+   */
+  title: string;
+  pitch: string;
+  role: string;
 }
 
 /**
@@ -15,7 +23,12 @@ interface GameDetailHeaderProps {
  * eyebrow row + display title + lede + meta ribbon) but reads
  * game-specific fields: engine, year, role, platforms, build links.
  */
-export async function GameDetailHeader({ game }: GameDetailHeaderProps) {
+export async function GameDetailHeader({
+  game,
+  title,
+  pitch,
+  role,
+}: GameDetailHeaderProps) {
   const t = await getTranslations("CaseStudy");
   const tGame = await getTranslations("Game");
   const tProjects = await getTranslations("Projects");
@@ -41,18 +54,18 @@ export async function GameDetailHeader({ game }: GameDetailHeaderProps) {
         </div>
 
         <h1 className="mt-6 max-w-5xl text-balance font-[family-name:var(--font-display)] text-[clamp(2.5rem,6vw,5.5rem)] font-semibold leading-[0.95] tracking-tight">
-          {game.title}
+          {title}
         </h1>
 
         <p className="mt-7 max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
-          {game.pitch}
+          {pitch}
         </p>
 
         <dl className="mt-10 grid gap-6 border-t pt-6 sm:grid-cols-[auto_1fr] sm:gap-x-10">
           <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
             {tProjects("role")}
           </dt>
-          <dd className="text-sm leading-7 text-foreground">{game.role}</dd>
+          <dd className="text-sm leading-7 text-foreground">{role}</dd>
 
           {game.platforms.length > 0 ? (
             <>

--- a/src/content/schemas.ts
+++ b/src/content/schemas.ts
@@ -159,6 +159,10 @@ export const gameSchema = z.object({
   buildLinks: z
     .array(z.object({ label: z.string(), url: z.string().url() }))
     .default([]),
+  // Phase 3.2 — per-locale translation overrides. Mirrors projectSchema.
+  // Same `localize()` helper at src/lib/content/localize.ts merges the
+  // active-locale slice into the base game object.
+  translations: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const mediaItemSchema = z.object({


### PR DESCRIPTION
## Summary

Closes the parity gap flagged by the Phase 1.3 code review:
`gameSchema` gains an optional `translations` field mirroring
`projectSchema`'s, and the `localize()` helper is now plumbed
through the game routes + homepage status pulse so `/zh` reads in
CJK whenever a game's `translations.zh` slice exists.

## What changed

### `src/content/schemas.ts`
- `gameSchema` gains `translations: z.record(z.string(), z.unknown()).optional()`.
  Mirrors `projectSchema`'s field exactly. **Non-breaking** —
  existing `src/content/games.ts` entries (3 placeholder/draft
  games, none with translations yet) parse without edits.

### `src/components/case-study/game-detail-header.tsx`
- Header API now mirrors `CaseStudyHeader`: accepts `title`,
  `pitch`, `role` as props in addition to the base `game`. The
  header keeps reading meta-ribbon fields (engine, year, platforms,
  buildLinks) directly from `game` since those don't typically
  need localization.

### `src/app/[locale]/games/[slug]/page.tsx`
- Calls `localize(game, locale)` and threads localized
  `title` / `pitch` / `role` into `GameDetailHeader`.
- `generateMetadata` localizes too.
- Adjacent prev/next game footer links localize their `title` and
  `pitch`.
- `PullQuoteBlock` (outcome) and the postmortem `CaseStudySection`
  fall back to the base game field when the locale slice doesn't
  override them — same pattern as project detail.

### `src/app/[locale]/games/page.tsx`
- Each game in the archive map is localized before being passed to
  `ArchiveCard`.

### `src/app/[locale]/page.tsx` (homepage `StatusPulseRow`)
- Both the **shipping** project entry and the **now** game entry
  are localized. Closes a pre-existing parity gap on the project
  side too — the previous implementation read raw `shipping.title`
  / `shipping.shortPitch` regardless of locale.

## Phase 1 patterns preserved
- Tokens only.
- No new packages.
- No content changes — the schema becomes future-proof; when an
  author adds a `translations.zh` slice to a game (mirroring the
  existing pattern on Nimbus / BioLoom / M4rketView projects),
  every surface picks it up automatically.

## Test plan
- [ ] CI green.
- [ ] Locally add `translations: { zh: { title: \"...\", pitch: \"...\" } }`
      to one game in `games.ts` → verify `/zh/games`, `/zh/games/[slug]`,
      and homepage status pulse render the CJK title.
- [ ] `/en/games` and `/zh/games` unchanged today (no translations
      exist yet).

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)