### PR TITLE
Phase 3.3 — CommandPalette mobile bottom-sheet variant (closes Sprint 3)

### DIFF
--- a/src/components/system/command-palette.tsx
+++ b/src/components/system/command-palette.tsx
@@ -103,13 +103,15 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         hideCloseButton
-        className="max-w-xl gap-0 overflow-hidden p-0"
+        // Below md: bottom-anchored sheet (full-width, top-rounded only).
+        // md+: keep the centered modal layout from DialogContent's defaults.
+        className="max-w-xl gap-0 overflow-hidden p-0 max-md:left-0 max-md:right-0 max-md:bottom-0 max-md:top-auto max-md:w-full max-md:max-w-none max-md:translate-x-0 max-md:translate-y-0 max-md:rounded-b-none"
       >
         <VisuallyHidden>
           <DialogTitle>{tPalette("title")}</DialogTitle>
           <DialogDescription>{tPalette("description")}</DialogDescription>
         </VisuallyHidden>
-        <Command label={tPalette("title")} className="rounded-md">
+        <Command label={tPalette("title")} className="rounded-md max-md:rounded-b-none">
           <CommandInput placeholder={tPalette("searchPlaceholder")} />
           <CommandList>
             <CommandEmpty>{tPalette("noResults")}</CommandEmpty>
@@ -192,7 +194,9 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             </CommandGroup>
           </CommandList>
 
-          <div className="flex items-center justify-end gap-2 border-t px-3 py-2 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground">
+          {/* Keyboard hint strip — hidden on touch / small screens since
+              the kbd shortcuts don't apply there. */}
+          <div className="hidden items-center justify-end gap-2 border-t px-3 py-2 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground md:flex">
             <span>{tPalette("hintNavigate")}</span>
             <kbd className="rounded border px-1.5 py-0.5">↑↓</kbd>
             <span>{tPalette("hintSelect")}</span>


### PR DESCRIPTION
## Summary

Closes Sprint 3 (infrastructure pass). The Cmd-K palette shipped in
Phase 1.7 has been desktop-only — a centered `Dialog` modal that,
on small screens, lands as a tight box floating in the middle of a
phone viewport. This PR anchors the palette to the bottom of the
viewport on mobile and reads as a proper bottom sheet, while
keeping the centered modal layout at md+.

## Implementation

- **Pure CSS** via Tailwind 4's `max-md:` responsive variant — no
  new primitive, no JS branching, no breakpoint hooks.
- `DialogContent` at `max-md` unmounts the centered
  `-translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2` positioning
  and re-anchors to `bottom-0 left-0 right-0` with full width and
  top-rounded corners only.
- The `Command` surface inside the dialog mirrors the corner change
  (`max-md:rounded-b-none`) so the bottom edge meets the viewport
  cleanly.
- The keyboard hint strip (`↑↓ navigate / ↵ select / esc close`) is
  hidden below `md` — those shortcuts don't apply to touch users,
  so the strip was visual debt on mobile.

## Why no Radix primitive change

`Sheet` is currently re-exported from `Dialog`
(`src/components/ui/sheet.tsx` is `export { Dialog as Sheet }`), so
a true bottom-sheet primitive doesn't exist yet. The CSS-only
variant achieves the same visual result without forking the
primitive — `DialogContent`'s existing `hideCloseButton` prop
already accommodates the palette's special case.

All other `DialogContent` consumers (gallery lightbox, saved-frames
clear confirm) are unchanged; they don't pass the bottom-sheet
override classes, so they continue to render centered on every
breakpoint.

## Sprint 3 — infrastructure pass summary

| Phase | What | PR |
|---|---|---|
| 3.1 | Tailwind 4 canonical-class sweep (44 + 33 substitutions across 28 files) | #23 |
| 3.2 | `gameSchema` translations parity + `localize()` plumbed through game routes | #24 |
| 3.3 | CommandPalette mobile bottom-sheet | this PR |

- Zero new runtime deps across the sprint.
- One pre-existing parity gap closed (homepage status pulse now
  localizes both project and game entries).

## Test plan

- [ ] Press Cmd/Ctrl-K on desktop (≥md): palette renders as a
      centered modal — same layout as before.
- [ ] Tap the mobile-nav search pill on a phone (or DevTools
      mobile emulation): palette anchors to the bottom of the
      viewport, full-width, top-rounded.
- [ ] Search input still receives focus on open.
- [ ] Tile/route selection still navigates correctly.
- [ ] Keyboard hint strip is hidden on mobile.
- [ ] Other Dialog consumers (gallery lightbox, saved page clear
      confirm) unchanged — verify on mobile that they still render
      centered.

\u{1F916} Generated with [Claude Code](https://claude.com/claude-code)