### PR TITLE
feat: phase-4.1 home polish — pointer spotlight + live signal + card lift

### DIFF
--- a/src/components/cards/project-card.tsx
+++ b/src/components/cards/project-card.tsx
@@ -45,7 +45,7 @@ export function ProjectCard({ project, locale, highlighted = false }: ProjectCar
       className="relative h-full"
     >
       {highlighted ? <BorderBeam duration={14} borderRadius={8} /> : null}
-      <Card className="group relative h-full overflow-hidden bg-card/80 transition-[border-color,box-shadow] duration-300 hover:border-ring/50 hover:shadow-lg">
+      <Card className="group relative h-full overflow-hidden bg-card/80 transition-[border-color,box-shadow] duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 hover:shadow-lg hover:shadow-ring/5">
         <div className="relative aspect-16/10 overflow-hidden border-b bg-muted">
           {cover ? (
             <Image

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, Code } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Marquee } from "@/components/ui/marquee"
 import { AnimatedGridPattern } from "@/components/ui/magic/animated-grid-pattern"
+import { PointerSpotlight } from "@/components/ui/magic/pointer-spotlight"
 import { Link } from "@/i18n/navigation"
 import type { Locale } from "@/i18n/routing"
 
@@ -54,6 +55,7 @@ export function HeroSection({ locale }: { locale: Locale }) {
       />
       <div className="noise-layer absolute inset-0" aria-hidden="true" />
       <div className="scanline-layer absolute inset-0 opacity-35" aria-hidden="true" />
+      <PointerSpotlight radius={420} intensity={0.14} />
 
       {/* main grid */}
       <div className="relative mx-auto grid min-h-[calc(100dvh-4rem-2.75rem)] w-full max-w-7xl items-center gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_400px] lg:gap-16 lg:px-8">

--- a/src/components/sections/status-pulse-row.tsx
+++ b/src/components/sections/status-pulse-row.tsx
@@ -25,10 +25,13 @@ export async function StatusPulseRow({ current, className }: StatusPulseRowProps
       {current.map((entry, index) => (
         <article
           key={`${entry.kind}-${index}`}
-          className="group flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50"
+          className="group flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 hover:shadow-md hover:shadow-ring/5"
         >
           <header className="flex items-center gap-2">
-            <span aria-hidden="true" className="size-2 rounded-full bg-signal" />
+            <span aria-hidden="true" className="relative grid size-2 place-items-center">
+              <span className="absolute inset-0 animate-ping rounded-full bg-signal/60 motion-reduce:hidden" />
+              <span className="relative size-2 rounded-full bg-signal" />
+            </span>
             <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
               {t(entry.kind)}
             </span>

--- a/src/components/sections/writing-pulse-row.tsx
+++ b/src/components/sections/writing-pulse-row.tsx
@@ -57,7 +57,7 @@ function PulseSlot({
   const eyebrow = t(eyebrowKeyBySlot[slot]);
 
   return (
-    <Card className="group flex h-full flex-col bg-card/80 transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50">
+    <Card className="group flex h-full flex-col bg-card/80 transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 hover:shadow-lg hover:shadow-ring/5">
       <CardHeader className="gap-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-wrap items-center gap-2">

--- a/src/components/ui/magic/pointer-spotlight.stories.tsx
+++ b/src/components/ui/magic/pointer-spotlight.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PointerSpotlight } from "./pointer-spotlight";
+
+const meta = {
+  title: "Magic UI/PointerSpotlight",
+  component: PointerSpotlight,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof PointerSpotlight>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function StageWrapper({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="relative h-[480px] w-full overflow-hidden border bg-background">
+      {children}
+      <div className="relative grid h-full place-items-center">
+        <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted-foreground">
+          {label}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <StageWrapper label="move cursor — soft cyan follows">
+      <PointerSpotlight />
+    </StageWrapper>
+  ),
+};
+
+export const LowIntensity: Story = {
+  render: () => (
+    <StageWrapper label="quieter / 6% intensity">
+      <PointerSpotlight intensity={0.06} />
+    </StageWrapper>
+  ),
+};
+
+export const HighIntensity: Story = {
+  render: () => (
+    <StageWrapper label="louder / 24% — overshoots the editorial brief, included only for reference">
+      <PointerSpotlight intensity={0.24} />
+    </StageWrapper>
+  ),
+};

--- a/src/components/ui/magic/pointer-spotlight.tsx
+++ b/src/components/ui/magic/pointer-spotlight.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+// Adapted from Aceternity / Magic UI · sprint-4 phase 4.1
+
+import { useEffect, useRef } from "react";
+import { useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface PointerSpotlightProps {
+  /** Radius of the spotlight circle in pixels. */
+  radius?: number;
+  /** 0–1 intensity multiplier on the highlight color. */
+  intensity?: number;
+  className?: string;
+}
+
+/**
+ * Renders an absolutely-positioned overlay that paints a soft radial
+ * gradient at the visitor's pointer position inside the *immediate*
+ * positioned parent. The component must live inside an element with
+ * `position: relative` (or absolute / fixed) for the overlay to fill
+ * it correctly.
+ *
+ * Pointer position is written to two CSS custom properties via
+ * `requestAnimationFrame` so we never re-render on `pointermove`.
+ *
+ * The overlay is always present in the DOM (so SSR and the first
+ * client render produce identical markup — no hydration mismatch).
+ * Visibility is gated by the `--spot-opacity` custom property, which
+ * stays `0` on touch devices and when `prefers-reduced-motion: reduce`
+ * is set, because the pointer listener is never attached in those
+ * cases.
+ */
+export function PointerSpotlight({
+  radius = 300,
+  intensity = 0.12,
+  className,
+}: PointerSpotlightProps) {
+  const reduceMotion = useReducedMotion();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const clamped = Math.max(0, Math.min(1, intensity));
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    if (typeof window === "undefined") return;
+    if (!window.matchMedia("(pointer: fine)").matches) return;
+
+    const node = ref.current;
+    if (!node) return;
+    // Listen on the parent so the spotlight tracks pointer over the
+    // whole hero, not just the empty overlay div on top.
+    const target = node.parentElement;
+    if (!target) return;
+
+    const handle = (event: PointerEvent) => {
+      const rect = target.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        node.style.setProperty("--spot-x", `${x}px`);
+        node.style.setProperty("--spot-y", `${y}px`);
+        node.style.setProperty("--spot-opacity", "1");
+        rafRef.current = null;
+      });
+    };
+
+    const leave = () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        node.style.setProperty("--spot-opacity", "0");
+        rafRef.current = null;
+      });
+    };
+
+    target.addEventListener("pointermove", handle);
+    target.addEventListener("pointerleave", leave);
+    return () => {
+      target.removeEventListener("pointermove", handle);
+      target.removeEventListener("pointerleave", leave);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [reduceMotion]);
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-0 z-10 transition-opacity duration-(--motion-fast) ease-(--ease-premium)",
+        className,
+      )}
+      style={{
+        opacity: "var(--spot-opacity, 0)",
+        background: `radial-gradient(circle ${radius}px at var(--spot-x, 50%) var(--spot-y, 50%), color-mix(in srgb, var(--ring) ${Math.round(clamped * 100)}%, transparent) 0%, transparent 70%)`,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Sprint 4 atmosphere push, phase 1 of 4 — homepage polish only. No new features.

- **PointerSpotlight** Magic UI primitive (`src/components/ui/magic/pointer-spotlight.tsx`) — soft cyan radial gradient that tracks pointer over the hero. Pointer position is written to CSS custom properties via `requestAnimationFrame` on a single `pointermove` listener attached to the parent element — no React state on move, no `window`-scoped listener. Listener short-circuits on touch (`pointer: coarse`) and `prefers-reduced-motion`; the (invisible) overlay always mounts so SSR hydration stays clean.
- Mounted on `HeroSection` behind the `AnimatedGridPattern` wash so it reads as one of the existing atmospheric layers.
- **Live signal dot** on `StatusPulseRow` — outer `animate-ping` ring with `motion-reduce:hidden` short-circuit on top of the existing `bg-signal` core. Reads as "this archive is live" without any new copy.
- Quiet hover shadow on `StatusPulseRow` and `WritingPulseRow` cards.
- `ProjectCard` transition migrates to the canonical Tailwind 4 `transition-[border-color,box-shadow] duration-(--motion-fast) ease-(--ease-premium)` so the new `hover:shadow-lg hover:shadow-ring/5` lifts in smoothly instead of snapping.

## Test plan
- [x] `npm run lint` silent
- [x] `npm run typecheck` silent
- [ ] Vercel CI green (Snyk + Socket + production build)
- [ ] Manual smoke: `/en` desktop — cursor moves across hero, soft cyan follows; status pulse dots ping; featured project cards lift on hover; first card retains BorderBeam.
- [ ] Manual smoke: `/zh` — same atmosphere, no string regressions.
- [ ] DevTools `prefers-reduced-motion: reduce` — spotlight invisible, ping ring hidden, hover transitions still allowed.
- [ ] DevTools touch emulation — spotlight invisible (listener never attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)