### PR TITLE
feat: phase-4.2 archives polish — hover link previews + canonical tokens

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { ThemeProvider } from "@/components/theme/theme-provider";
 import { CommandPaletteProvider } from "@/components/system/command-palette-provider";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { routing, type Locale } from "@/i18n/routing";
 
 export function generateStaticParams() {
@@ -27,7 +28,9 @@ export default async function LocaleLayout({
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
       <ThemeProvider>
-        <CommandPaletteProvider>{children}</CommandPaletteProvider>
+        <TooltipProvider delayDuration={400} skipDelayDuration={150}>
+          <CommandPaletteProvider>{children}</CommandPaletteProvider>
+        </TooltipProvider>
       </ThemeProvider>
     </NextIntlClientProvider>
   );

--- a/src/app/[locale]/projects/_client.tsx
+++ b/src/app/[locale]/projects/_client.tsx
@@ -207,6 +207,10 @@ export function ProjectsClient({
 
       {production.length > 0 ? (
         <Stagger
+          // Re-key on chip / year changes so the cards restagger smoothly.
+          // Search query is intentionally excluded — keystrokes would
+          // otherwise re-mount the grid mid-typing and steal focus state.
+          key={`stagger-${activeCategory ?? "all"}-${activeYear}`}
           className="mt-10 grid gap-5 md:grid-cols-2 xl:grid-cols-3"
           delay={0.05}
         >

--- a/src/components/cards/archive-card.tsx
+++ b/src/components/cards/archive-card.tsx
@@ -29,7 +29,7 @@ export function ArchiveCard({
   mediaLabel?: string
 }) {
   const content = (
-    <Card className="group h-full overflow-hidden bg-card/80 transition-[border-color,box-shadow] duration-200 hover:border-ring hover:shadow-md">
+    <Card className="group h-full overflow-hidden bg-card/80 transition-[border-color,box-shadow] duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/60 hover:shadow-md hover:shadow-ring/5">
       <PlaceholderImage
         label={mediaLabel}
         aspect="aspect-4/3"

--- a/src/components/cards/post-list-item.tsx
+++ b/src/components/cards/post-list-item.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/placeholders/draft-badge";
+import { LinkPreview } from "@/components/system/link-preview";
 import { Link } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import type { Post } from "@/content/schemas";
@@ -16,73 +17,89 @@ const monoMeta =
  * Single timeline row for /blog. The whole row is one Link — no
  * nested interactive elements. Mono date column on md+; on mobile,
  * date and reading time co-locate on a single meta line above the
- * title. Hover lifts background subtly; no scale, no shadow.
+ * title. Hover lifts background subtly; on desktop, hovering or
+ * keyboard-focusing also surfaces a `LinkPreview` with cover and
+ * excerpt.
  */
 export function PostListItem({ post }: PostListItemProps) {
   const isDraft = post.status !== "ready";
   return (
     <li>
-      <Link
-        href={`/blog/${post.slug}`}
-        className={cn(
-          "group grid gap-3 rounded-lg border border-transparent px-4 py-5 transition-colors duration-(--motion-fast) ease-(--ease-premium)",
-          "hover:border-border hover:bg-muted/30",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-          "md:grid-cols-[8rem_1fr_auto] md:items-baseline md:gap-6",
-        )}
+      <LinkPreview
+        title={post.title}
+        lede={post.excerpt}
+        eyebrow={post.category}
+        placeholderLabel="POST COVER TBD"
+        side="right"
+        align="start"
       >
-        {/* Mobile-only meta line: date · reading time */}
-        <div
+        <Link
+          href={`/blog/${post.slug}`}
           className={cn(
-            "flex flex-wrap items-center gap-x-3 gap-y-1",
-            "md:hidden",
+            "group grid gap-3 rounded-lg border border-transparent px-4 py-5 transition-colors duration-(--motion-fast) ease-(--ease-premium)",
+            "hover:border-border hover:bg-muted/30",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            "md:grid-cols-[8rem_1fr_auto] md:items-baseline md:gap-6",
           )}
         >
-          <span className={monoMeta}>{post.date}</span>
-          <span aria-hidden="true" className="text-muted-foreground/40">
-            ·
-          </span>
-          <span className={monoMeta}>{post.readingTime}</span>
-        </div>
-
-        {/* Desktop-only: standalone date column */}
-        <span className={cn(monoMeta, "hidden md:inline")}>{post.date}</span>
-
-        <div className="grid gap-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className={monoMeta}>{post.category}</span>
-            {isDraft ? <DraftBadge label={post.status} /> : null}
+          {/* Mobile-only meta line: date · reading time */}
+          <div
+            className={cn(
+              "flex flex-wrap items-center gap-x-3 gap-y-1",
+              "md:hidden",
+            )}
+          >
+            <span className={monoMeta}>{post.date}</span>
+            <span aria-hidden="true" className="text-muted-foreground/40">
+              ·
+            </span>
+            <span className={monoMeta}>{post.readingTime}</span>
           </div>
-          <h3 className="text-lg font-semibold leading-snug text-foreground">
-            {post.title}
-            <ArrowUpRight
-              aria-hidden="true"
-              className="ml-1 inline size-4 -translate-y-0.5 text-muted-foreground transition-transform duration-(--motion-fast) group-hover:-translate-y-1.5 group-hover:translate-x-0.5 group-hover:text-foreground"
-            />
-          </h3>
-          <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
-            {post.excerpt}
-          </p>
-          {post.tags.length > 0 ? (
-            <div className="flex flex-wrap gap-1.5">
-              {post.tags.map((tag) => (
-                <Badge
-                  key={tag}
-                  variant="outline"
-                  className="text-[0.6rem] lowercase tracking-[0.1em]"
-                >
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          ) : null}
-        </div>
 
-        {/* Desktop-only: reading time, right-aligned */}
-        <span className={cn(monoMeta, "hidden shrink-0 md:inline md:text-right")}>
-          {post.readingTime}
-        </span>
-      </Link>
+          {/* Desktop-only: standalone date column */}
+          <span className={cn(monoMeta, "hidden md:inline")}>{post.date}</span>
+
+          <div className="grid gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={monoMeta}>{post.category}</span>
+              {isDraft ? <DraftBadge label={post.status} /> : null}
+            </div>
+            <h3 className="text-lg font-semibold leading-snug text-foreground">
+              {post.title}
+              <ArrowUpRight
+                aria-hidden="true"
+                className="ml-1 inline size-4 -translate-y-0.5 text-muted-foreground transition-transform duration-(--motion-fast) group-hover:-translate-y-1.5 group-hover:translate-x-0.5 group-hover:text-foreground"
+              />
+            </h3>
+            <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+              {post.excerpt}
+            </p>
+            {post.tags.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {post.tags.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant="outline"
+                    className="text-[0.6rem] lowercase tracking-[0.1em]"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          {/* Desktop-only: reading time, right-aligned */}
+          <span
+            className={cn(
+              monoMeta,
+              "hidden shrink-0 md:inline md:text-right",
+            )}
+          >
+            {post.readingTime}
+          </span>
+        </Link>
+      </LinkPreview>
     </li>
   );
 }

--- a/src/components/system/link-preview.stories.tsx
+++ b/src/components/system/link-preview.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { LinkPreview } from "./link-preview";
+
+const meta = {
+  title: "System/LinkPreview",
+  component: LinkPreview,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <TooltipProvider delayDuration={200}>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+} satisfies Meta<typeof LinkPreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const TriggerLink = ({ children }: { children: React.ReactNode }) => (
+  <a
+    href="#"
+    className="rounded px-3 py-1.5 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+  >
+    {children}
+  </a>
+);
+
+export const Placeholder: Story = {
+  args: {
+    title: "Rebuilding M4rkyu.com as a black-and-white archive",
+    lede: "Final notes on the design-system decisions, route architecture, and performance constraints.",
+    eyebrow: "Devlog",
+    placeholderLabel: "POST COVER TBD",
+    children: <TriggerLink>Hover this title</TriggerLink>,
+  },
+};
+
+export const WithCover: Story = {
+  args: {
+    title: "Nimbus case study",
+    lede: "A secure file-management platform shaped around calm organization, OTP access, and storage analytics.",
+    eyebrow: "Web app",
+    image: { src: "/project-covers/nimbus.svg", alt: "Nimbus monochrome cover" },
+    children: <TriggerLink>Hover this title</TriggerLink>,
+  },
+};
+
+export const NoLede: Story = {
+  args: {
+    title: "Compact preview",
+    eyebrow: "Eyebrow only",
+    placeholderLabel: "FRAME TBD",
+    children: <TriggerLink>Hover this title</TriggerLink>,
+  },
+};

--- a/src/components/system/link-preview.tsx
+++ b/src/components/system/link-preview.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Image from "next/image";
+import type { ReactNode } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
+
+interface LinkPreviewProps {
+  /** Title displayed in the preview card. */
+  title: string;
+  /** One- or two-line lede shown below the title. */
+  lede?: string;
+  /** Optional cover image. Falls back to PlaceholderImage when omitted. */
+  image?: { src: string; alt: string };
+  /** Optional eyebrow / metadata line above the title. */
+  eyebrow?: string;
+  /** Optional placeholder label for the fallback image. */
+  placeholderLabel?: string;
+  /** Side preference for the preview, forwarded to Radix. */
+  side?: "top" | "right" | "bottom" | "left";
+  /** Tooltip alignment, forwarded to Radix. */
+  align?: "start" | "center" | "end";
+  /** The trigger content — usually a `<Link>` wrapping a title. */
+  children: ReactNode;
+}
+
+/**
+ * Hover/focus-triggered preview for archive links. Wraps Radix
+ * Tooltip with a richer content card (cover + eyebrow + title +
+ * lede). Touch devices skip the preview by Radix default.
+ *
+ * The trigger is `asChild` so the visible link/title element
+ * stays the focusable / clickable target — the preview only
+ * adds the hover affordance.
+ */
+export function LinkPreview({
+  title,
+  lede,
+  image,
+  eyebrow,
+  placeholderLabel = "FRAME TBD",
+  side = "right",
+  align = "start",
+  children,
+}: LinkPreviewProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        side={side}
+        align={align}
+        className="w-72 rounded-lg border-border bg-popover p-0 text-popover-foreground shadow-lg"
+      >
+        <div className="relative aspect-16/10 w-full overflow-hidden rounded-t-lg bg-muted">
+          {image ? (
+            <Image
+              src={image.src}
+              alt={image.alt}
+              fill
+              sizes="288px"
+              className="object-cover"
+            />
+          ) : (
+            <PlaceholderImage
+              label={placeholderLabel}
+              aspect="h-full"
+              className="rounded-none border-0"
+            />
+          )}
+        </div>
+        <div className="grid gap-1.5 p-3">
+          {eyebrow ? (
+            <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+              {eyebrow}
+            </p>
+          ) : null}
+          <p className="text-sm font-semibold leading-snug text-foreground">
+            {title}
+          </p>
+          {lede ? (
+            <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
+              {lede}
+            </p>
+          ) : null}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/theme/theme-switcher.tsx
+++ b/src/components/theme/theme-switcher.tsx
@@ -3,7 +3,7 @@
 import { Moon, Sun, CircleDot } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const themes = [
   { value: "dark", label: "Dark", icon: Moon },
@@ -15,31 +15,29 @@ export function ThemeSwitcher() {
   const { theme, setTheme } = useTheme();
 
   return (
-    <TooltipProvider delayDuration={150}>
-      <div className="flex items-center gap-1 rounded-md border bg-background/70 p-1 backdrop-blur">
-        {themes.map((item) => {
-          const Icon = item.icon;
-          const active = theme === item.value;
-          return (
-            <Tooltip key={item.value}>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant={active ? "secondary" : "ghost"}
-                  size="icon"
-                  aria-label={`Use ${item.label} theme`}
-                  aria-pressed={active}
-                  data-testid={`theme-${item.value}`}
-                  onClick={() => setTheme(item.value)}
-                >
-                  <Icon className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{item.label}</TooltipContent>
-            </Tooltip>
-          );
-        })}
-      </div>
-    </TooltipProvider>
+    <div className="flex items-center gap-1 rounded-md border bg-background/70 p-1 backdrop-blur">
+      {themes.map((item) => {
+        const Icon = item.icon;
+        const active = theme === item.value;
+        return (
+          <Tooltip key={item.value}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant={active ? "secondary" : "ghost"}
+                size="icon"
+                aria-label={`Use ${item.label} theme`}
+                aria-pressed={active}
+                data-testid={`theme-${item.value}`}
+                onClick={() => setTheme(item.value)}
+              >
+                <Icon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{item.label}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
   );
 }

--- a/src/components/ui/tooltip.stories.tsx
+++ b/src/components/ui/tooltip.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button } from "./button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+
+const meta = {
+  title: "UI/Tooltip",
+  component: Tooltip,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover me</Button>
+        </TooltipTrigger>
+        <TooltipContent>One-line tooltip text</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};
+
+export const RichContent: Story = {
+  render: () => (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Rich tooltip</Button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs px-3 py-2">
+          <p className="font-mono text-[0.6rem] uppercase tracking-[0.2em] text-muted-foreground">
+            metadata
+          </p>
+          <p className="mt-1 text-sm font-semibold">Headline</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Two-line lede that explains what the trigger represents in
+            slightly more detail.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};


### PR DESCRIPTION
## Summary

Sprint 4 atmosphere push, phase 2 of 4 — archive surfaces gain hover previews and motion-token consistency.

- **LinkPreview** primitive (`src/components/system/link-preview.tsx`) — Radix-Tooltip-driven preview card. `TooltipTrigger asChild` keeps the consumer link as the focus + click target; the tooltip opens on hover (after 400ms via the global provider) and on keyboard focus. Content: 16:10 cover (next/image with `PlaceholderImage` fallback) + eyebrow + title + 2-line lede. Touch devices skip the preview by Radix default.
- **Global TooltipProvider** mounted in `[locale]/layout.tsx` with `delayDuration={400}` and `skipDelayDuration={150}` so adjacent items in lists reuse the open state. The redundant nested provider in `theme-switcher.tsx` was removed — it overrode the global delay for theme buttons only.
- **PostListItem** (timeline rows on `/blog`) wraps its row `<Link>` in `LinkPreview`. Hovering or keyboard-focusing surfaces a richer preview with category eyebrow, title, and excerpt. Real cover images will plug in once they ship; until then the `PlaceholderImage` keeps the preview honest.
- **ArchiveCard** (used on `/games`) migrates from `transition-[border-color,box-shadow] duration-200` to canonical `transition-[border-color,box-shadow] duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/60 hover:shadow-md hover:shadow-ring/5`.
- **Projects archive** `<Stagger>` re-keys on chip / year changes so cards restagger smoothly. Search keystrokes are intentionally excluded so the grid does not remount mid-typing.
- **Storybook**: new stories for `tooltip` and `link-preview`.

## Test plan
- [x] `npm run lint` silent
- [x] `npm run typecheck` silent
- [ ] Vercel CI green (Snyk + Socket + production build)
- [ ] Manual smoke: `/en/blog` desktop — hover a timeline title → preview opens after 400ms with cover placeholder + category eyebrow + title + excerpt; tab to a row → preview opens on focus; Escape dismisses.
- [ ] Manual smoke: `/en/projects` desktop — change category chip / year select → grid restaggers; type in search → cards filter without restagger jank.
- [ ] Manual smoke: `/zh/blog` — preview eyebrow reads from `post.category` (currently English data — translation pass when content lands).
- [ ] DevTools touch emulation — tooltip does not open on tap; Link still navigates normally.
- [ ] DevTools `prefers-reduced-motion: reduce` — tooltip animations short-circuit; cards still hover-lift via CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)