### PR TITLE
feat: phase-4.3 detail polish — cross-route fade + prev/next previews + pull-quote refinement

### DIFF
--- a/src/components/case-study/case-study-footer.tsx
+++ b/src/components/case-study/case-study-footer.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
+import { LinkPreview } from "@/components/system/link-preview";
 import { Link } from "@/i18n/navigation";
 
 export interface CaseStudyAdjacentEntry {
@@ -73,25 +74,43 @@ function CaseStudyAdjacent({
   const isNext = direction === "next";
 
   return (
-    <Link
-      href={entry.href}
-      className={`group flex flex-col gap-2 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-        isNext ? "lg:text-right" : ""
-      }`}
+    <LinkPreview
+      title={entry.title}
+      lede={entry.pitch}
+      placeholderLabel="ADJACENT MEDIA TBD"
+      side={isNext ? "left" : "right"}
+      align="start"
     >
-      <span
-        className={`flex items-center gap-1.5 font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground ${
-          isNext ? "lg:justify-end" : ""
+      <Link
+        href={entry.href}
+        className={`group flex flex-col gap-2 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-[border-color,box-shadow] duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 hover:shadow-md hover:shadow-ring/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+          isNext ? "lg:text-right" : ""
         }`}
       >
-        {!isNext ? <ArrowLeft aria-hidden="true" className="size-3" /> : null}
-        {label}
-        {isNext ? <ArrowRight aria-hidden="true" className="size-3" /> : null}
-      </span>
-      <span className="text-lg font-semibold leading-snug">{entry.title}</span>
-      <span className="line-clamp-2 text-sm leading-6 text-muted-foreground">
-        {entry.pitch}
-      </span>
-    </Link>
+        <span
+          className={`flex items-center gap-1.5 font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground ${
+            isNext ? "lg:justify-end" : ""
+          }`}
+        >
+          {!isNext ? (
+            <ArrowLeft
+              aria-hidden="true"
+              className="size-3 transition-transform duration-(--motion-fast) ease-(--ease-premium) group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
+            />
+          ) : null}
+          {label}
+          {isNext ? (
+            <ArrowRight
+              aria-hidden="true"
+              className="size-3 transition-transform duration-(--motion-fast) ease-(--ease-premium) group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5"
+            />
+          ) : null}
+        </span>
+        <span className="text-lg font-semibold leading-snug">{entry.title}</span>
+        <span className="line-clamp-2 text-sm leading-6 text-muted-foreground">
+          {entry.pitch}
+        </span>
+      </Link>
+    </LinkPreview>
   );
 }

--- a/src/components/case-study/pull-quote-block.tsx
+++ b/src/components/case-study/pull-quote-block.tsx
@@ -25,16 +25,25 @@ export function PullQuoteBlock({
       )}
     >
       {eyebrow ? (
-        <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
+        <p className="flex items-center gap-3 font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
+          <span aria-hidden="true" className="h-px w-8 bg-foreground/20" />
           {eyebrow}
         </p>
       ) : null}
-      <blockquote className="mt-4 text-balance font-[family-name:var(--font-display)] text-2xl font-medium leading-tight tracking-tight text-foreground sm:text-3xl lg:text-4xl">
+      <blockquote
+        className={cn(
+          "text-balance font-[family-name:var(--font-display)] text-2xl font-medium leading-[1.2] tracking-tight text-foreground sm:text-3xl sm:leading-[1.18] lg:text-4xl lg:leading-[1.15]",
+          eyebrow ? "mt-5" : "",
+        )}
+      >
         {quote}
       </blockquote>
       {attribution ? (
-        <figcaption className="mt-6 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
-          — {attribution}
+        <figcaption className="mt-6 flex items-center gap-3 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          <span aria-hidden="true" className="h-px w-6 bg-foreground/20" />
+          {/* sr-only em-dash keeps the attribution audibly separated from the quote. */}
+          <span className="sr-only">— </span>
+          <cite className="not-italic">{attribution}</cite>
         </figcaption>
       ) : null}
     </figure>

--- a/src/components/layout/page-shell.tsx
+++ b/src/components/layout/page-shell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { Locale } from "@/i18n/routing";
 import { Header } from "./header";
 import { Footer } from "./footer";
+import { PageFade } from "@/components/motion/page-fade";
 
 export async function PageShell({
   locale,
@@ -20,7 +21,7 @@ export async function PageShell({
       </a>
       <Header locale={locale} />
       <main id="main-content" className="flex-1">
-        {children}
+        <PageFade>{children}</PageFade>
       </main>
       <Footer locale={locale} />
     </div>

--- a/src/components/motion/page-fade.stories.tsx
+++ b/src/components/motion/page-fade.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PageFade } from "./page-fade";
+
+const meta = {
+  title: "Motion/PageFade",
+  component: PageFade,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof PageFade>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div className="mx-auto max-w-2xl space-y-4 p-12">
+        <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+          page · /example
+        </p>
+        <h1 className="text-3xl font-semibold leading-tight">
+          Cross-route fade preview
+        </h1>
+        <p className="text-base leading-7 text-muted-foreground">
+          PageFade wraps page content with a 150ms opacity + 8px y-offset
+          entry animation keyed by the current pathname. There is no exit
+          animation; the App Router does not surface unmount cleanly without
+          complex layout choreography. Reload the story to replay the entry.
+        </p>
+      </div>
+    ),
+  },
+};

--- a/src/components/motion/page-fade.tsx
+++ b/src/components/motion/page-fade.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+/**
+ * Wraps page content in a 150ms opacity + 8px y-offset entry
+ * animation keyed by `usePathname()`. Each route mount re-runs the
+ * animation — there is no exit animation because the App Router
+ * does not surface unmount cleanly without complex layout
+ * choreography. Entry-only is honest.
+ *
+ * Short-circuits to the unwrapped children when `useReducedMotion()`
+ * returns true.
+ */
+export function PageFade({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) {
+    return <>{children}</>;
+  }
+
+  return (
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      // Cubic-bezier mirrors --ease-premium; motion's transition.ease cannot read CSS variables.
+      transition={{ duration: 0.15, ease: [0.2, 0.7, 0.2, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint 4 atmosphere push, phase 3 of 4 — case-study detail surfaces gain motion + a richer pull quote.

- **PageFade** (`src/components/motion/page-fade.tsx`) — 150ms opacity + 8px y-offset entry animation keyed by `usePathname()`. Mounted inside `PageShell`'s `<main>` so every route fades in; header and footer stay static. Reduced-motion → returns unwrapped children.
- **CaseStudyFooter** — prev/next cards wrap in `LinkPreview` (Phase 4.2). Preview shows title + pitch only — no eyebrow, to differentiate the preview content from the trigger card. Card transition migrates to `transition-[border-color,box-shadow]` with `hover:shadow-md hover:shadow-ring/5`. Arrow icons gain a 0.5px slide on `group-hover` and `group-focus-visible` for keyboard parity.
- **PullQuoteBlock** —
  - Eyebrow gains a thin `h-px w-8 bg-foreground/20` rule before the text.
  - Blockquote line-height tightens via responsive `leading-[1.2/1.18/1.15]`.
  - Attribution swaps the literal em-dash for a 1px rule with an `sr-only` em-dash so the visible mark is decorative but screen readers still hear the separation. Wraps in `<cite>` for semantics.
  - `mt-5` on the blockquote becomes conditional on eyebrow presence.
- **Storybook**: `page-fade.stories.tsx`.

## Test plan
- [x] `npm run lint` silent
- [x] `npm run typecheck` silent
- [ ] Vercel CI green (Snyk + Socket + production build)
- [ ] Manual smoke: navigate `/en/projects` → click a card → 150ms cross-fade into detail; back-button → archive fades back; same on `/en/games/[slug]`.
- [ ] Manual smoke: hover prev/next at the bottom of any case study → preview opens; arrow slides on hover and on keyboard focus (Tab into card).
- [ ] Manual smoke: pull-quote eyebrow + attribution rule reads in light + dark + monochrome theme.
- [ ] DevTools `prefers-reduced-motion: reduce` — page fade disabled, arrow slides instant; preview tooltip animations honor reduced-motion via Radix defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)