### PR TITLE
feat: phase-4.4 sparse-page polish — ShineBorder + Particles + Portal refresh

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -189,8 +189,18 @@
     "intro": "A China to Canada software and art path shaped by Western University, J.D. Power, game development, and a sustained interest in systems that feel human."
   },
   "Portal": {
-    "title": "Portal locked",
-    "intro": "An opt-in interactive mode is being assembled. For now, the terminal stays light, fast, and quiet."
+    "title": "Portal",
+    "intro": "An opt-in interactive route. For now, the terminal stays light, fast, and quiet — atmosphere only.",
+    "shellTitle": "prototype-shell",
+    "shellSubtitle": "client-only · no telemetry",
+    "shellStatus": "STANDBY",
+    "shellSlotStatus": "QUEUED",
+    "shellSlot": {
+      "caseStudies": "case-studies",
+      "gallery": "gallery",
+      "media": "media"
+    },
+    "shellFootnote": "An interactive mode will land alongside real game and gallery content. No heavy WebGL ships here."
   },
   "Common": {
     "comingSoon": "Coming soon",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -189,8 +189,18 @@
     "intro": "从中国到加拿大，从 Western University 到 J.D. Power，再到软件、游戏与艺术的交叉实践。Mark 关注的是有温度的系统。"
   },
   "Portal": {
-    "title": "Portal 已锁定",
-    "intro": "沉浸式交互模式正在构建中。当前版本保持轻量、快速、安静。"
+    "title": "Portal",
+    "intro": "可选的交互式路由。当前保持轻量、快速、安静 —— 仅有氛围层。",
+    "shellTitle": "prototype-shell",
+    "shellSubtitle": "纯客户端 · 无遥测",
+    "shellStatus": "待机",
+    "shellSlotStatus": "排队中",
+    "shellSlot": {
+      "caseStudies": "案例",
+      "gallery": "影像",
+      "media": "媒体"
+    },
+    "shellFootnote": "交互模式将随真实游戏与影像内容一起上线。这里不会运行重量级 WebGL。"
   },
   "Common": {
     "comingSoon": "即将开放",

--- a/src/app/[locale]/portal/page.tsx
+++ b/src/app/[locale]/portal/page.tsx
@@ -1,10 +1,11 @@
 import { getTranslations } from "next-intl/server";
-import { LockKeyhole, Terminal } from "lucide-react";
+import { Terminal } from "lucide-react";
 import { PageShell } from "@/components/layout/page-shell";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { ContentPendingLabel } from "@/components/placeholders/content-pending-label";
+import { Particles } from "@/components/ui/magic/particles";
+import { ShineBorder } from "@/components/ui/magic/shine-border";
 import { Link } from "@/i18n/navigation";
 import type { Locale } from "@/i18n/routing";
 
@@ -13,19 +14,21 @@ const bootLines = [
   "> webgl: disabled by default",
   "> motion: reduced-motion aware",
   "> assets: placeholder frames active",
-  "> status: CONTENT PENDING",
+  "> status: standby",
 ];
 
 export default async function PortalPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "Portal" });
+  const tNav = await getTranslations({ locale, namespace: "Navigation" });
 
   return (
     <PageShell locale={locale}>
       <section className="relative min-h-[78dvh] overflow-hidden border-b">
         <div className="absolute inset-0 bg-cyber-grid opacity-45" aria-hidden="true" />
         <div className="noise-layer absolute inset-0" aria-hidden="true" />
-        <div className="scanline-layer absolute inset-0 opacity-45" aria-hidden="true" />
+        <div className="scanline-layer absolute inset-0 opacity-35" aria-hidden="true" />
+        <Particles quantity={32} maxOpacity={0.5} speed={0.08} />
         <div className="relative mx-auto grid min-h-[78dvh] w-full max-w-7xl items-center gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[0.95fr_1.05fr] lg:px-8">
           <div>
             <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted-foreground">
@@ -35,21 +38,23 @@ export default async function PortalPage({ params }: { params: Promise<{ locale:
               {t("title")}
             </h1>
             <p className="mt-6 max-w-2xl text-base leading-8 text-muted-foreground">
-              {t("intro")} Draft placeholder mode keeps the main site fast until the immersive
-              route has a real interaction model.
+              {t("intro")}
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild>
                 <Link href="/projects" locale={locale}>
-                  Return to archive
+                  {tNav("projects")}
                 </Link>
               </Button>
-              <Button variant="outline" disabled>
-                Kernel mode TBD
+              <Button asChild variant="outline">
+                <Link href="/" locale={locale}>
+                  {tNav("home")}
+                </Link>
               </Button>
             </div>
           </div>
-          <Card className="overflow-hidden bg-background/80 font-mono backdrop-blur">
+          <Card className="relative overflow-hidden bg-background/80 font-mono backdrop-blur">
+            <ShineBorder borderRadius={12} duration={18} />
             <CardHeader className="border-b">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
@@ -57,11 +62,18 @@ export default async function PortalPage({ params }: { params: Promise<{ locale:
                     <Terminal className="size-5" aria-hidden="true" />
                   </span>
                   <div>
-                    <CardTitle>locked-terminal</CardTitle>
-                    <p className="mt-1 text-xs text-muted-foreground">Prototype shell</p>
+                    <CardTitle>{t("shellTitle")}</CardTitle>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t("shellSubtitle")}
+                    </p>
                   </div>
                 </div>
-                <ContentPendingLabel label="LOCKED" />
+                <Badge
+                  variant="outline"
+                  className="font-mono text-[0.6rem] uppercase tracking-[0.18em]"
+                >
+                  {t("shellStatus")}
+                </Badge>
               </div>
             </CardHeader>
             <CardContent className="p-5">
@@ -71,19 +83,23 @@ export default async function PortalPage({ params }: { params: Promise<{ locale:
                 ))}
               </div>
               <div className="mt-8 grid gap-3 sm:grid-cols-3">
-                {["case-studies", "gallery", "media"].map((item) => (
-                  <div key={item} className="rounded-md border bg-card/70 p-3">
-                    <Badge variant="warning">TBD</Badge>
-                    <p className="mt-3 text-xs uppercase tracking-[0.16em]">{item}</p>
+                {(["caseStudies", "gallery", "media"] as const).map((key) => (
+                  <div
+                    key={key}
+                    className="rounded-md border bg-card/70 p-3 transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/40"
+                  >
+                    <Badge variant="outline" className="text-[0.6rem]">
+                      {t("shellSlotStatus")}
+                    </Badge>
+                    <p className="mt-3 text-xs uppercase tracking-[0.16em]">
+                      {t(`shellSlot.${key}`)}
+                    </p>
                   </div>
                 ))}
               </div>
-              <div className="mt-8 flex items-center gap-3 rounded-md border bg-card/70 p-4">
-                <LockKeyhole className="size-5 text-muted-foreground" aria-hidden="true" />
-                <p className="text-xs leading-5 text-muted-foreground">
-                  Coming soon: opt-in interactive mode. No heavy WebGL ships here in phase II.
-                </p>
-              </div>
+              <p className="mt-8 rounded-md border bg-card/70 p-4 text-xs leading-5 text-muted-foreground">
+                {t("shellFootnote")}
+              </p>
             </CardContent>
           </Card>
         </div>

--- a/src/components/cards/resource-preview-card.tsx
+++ b/src/components/cards/resource-preview-card.tsx
@@ -19,7 +19,7 @@ export function ResourcePreviewCard({ resource }: ResourcePreviewCardProps) {
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`${resource.name} — opens in a new tab`}
-      className="group flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:-translate-y-0.5 hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      className="group flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-[border-color,transform,box-shadow] duration-(--motion-fast) ease-(--ease-premium) hover:-translate-y-0.5 hover:border-ring/50 hover:shadow-md hover:shadow-ring/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">

--- a/src/components/ui/magic/particles.stories.tsx
+++ b/src/components/ui/magic/particles.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Particles } from "./particles";
+
+const meta = {
+  title: "Magic UI/Particles",
+  component: Particles,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof Particles>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function StageWrapper({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="relative h-[480px] w-full overflow-hidden border bg-background">
+      {children}
+      <div className="relative grid h-full place-items-center">
+        <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted-foreground">
+          {label}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <StageWrapper label="ambient drift — 32 particles">
+      <Particles />
+    </StageWrapper>
+  ),
+};
+
+export const Dense: Story = {
+  render: () => (
+    <StageWrapper label="dense — 80 particles (use sparingly)">
+      <Particles quantity={80} maxOpacity={0.4} />
+    </StageWrapper>
+  ),
+};
+
+export const Slow: Story = {
+  render: () => (
+    <StageWrapper label="slow drift">
+      <Particles speed={0.04} />
+    </StageWrapper>
+  ),
+};

--- a/src/components/ui/magic/particles.tsx
+++ b/src/components/ui/magic/particles.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+// Adapted from Magic UI · sprint-4 phase 4.4
+
+import { useEffect, useRef } from "react";
+import { useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface ParticlesProps {
+  /** Total particle count. Cap low — defaults to 32. */
+  quantity?: number;
+  /** Maximum particle radius in CSS pixels. Default: 1.4. */
+  size?: number;
+  /** Drift speed multiplier in pixels per frame. Default: 0.1. */
+  speed?: number;
+  /** Particle color. Default: var(--ring). */
+  color?: string;
+  /** 0–1 max alpha. Default: 0.55. */
+  maxOpacity?: number;
+  className?: string;
+}
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  a: number;
+}
+
+/**
+ * Sparse drifting dots — ambient atmosphere only. Draws to a single
+ * canvas with `requestAnimationFrame`; no per-particle DOM nodes.
+ * The container must be `position: relative` (or absolute / fixed)
+ * so the canvas can fill it.
+ *
+ * Short-circuits to `null` on `prefers-reduced-motion: reduce`.
+ */
+export function Particles({
+  quantity = 32,
+  size = 1.4,
+  speed = 0.1,
+  color = "var(--ring)",
+  maxOpacity = 0.55,
+  className,
+}: ParticlesProps) {
+  const reduceMotion = useReducedMotion();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    // Resolve the CSS color once via a hidden element so we can plug
+    // it into ctx.fillStyle (canvas does not understand var(...)).
+    const probe = document.createElement("span");
+    probe.style.color = color;
+    document.body.appendChild(probe);
+    let resolvedColor: string;
+    try {
+      resolvedColor = getComputedStyle(probe).color;
+    } finally {
+      document.body.removeChild(probe);
+    }
+
+    function fitCanvas() {
+      if (!canvas) return;
+      const { width, height } = canvas.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.floor(width * dpr));
+      canvas.height = Math.max(1, Math.floor(height * dpr));
+      // Reset the transform before scaling — canvas 2D transforms are
+      // cumulative, and ResizeObserver can fire repeatedly.
+      if (ctx) {
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.scale(dpr, dpr);
+      }
+    }
+
+    function seed() {
+      if (!canvas) return;
+      const { width, height } = canvas.getBoundingClientRect();
+      particlesRef.current = Array.from({ length: quantity }, () => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        vx: (Math.random() - 0.5) * speed,
+        vy: (Math.random() - 0.5) * speed,
+        r: Math.random() * size + 0.4,
+        a: Math.random() * maxOpacity,
+      }));
+    }
+
+    function tick() {
+      if (!canvas || !ctx) return;
+      const { width, height } = canvas.getBoundingClientRect();
+      ctx.clearRect(0, 0, width, height);
+      for (const p of particlesRef.current) {
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x < -2) p.x = width + 2;
+        if (p.x > width + 2) p.x = -2;
+        if (p.y < -2) p.y = height + 2;
+        if (p.y > height + 2) p.y = -2;
+        ctx.beginPath();
+        ctx.fillStyle = resolvedColor;
+        ctx.globalAlpha = p.a;
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    fitCanvas();
+    seed();
+    rafRef.current = requestAnimationFrame(tick);
+
+    const observer = new ResizeObserver(() => {
+      fitCanvas();
+      seed();
+    });
+    observer.observe(canvas);
+
+    return () => {
+      observer.disconnect();
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [reduceMotion, quantity, size, speed, color, maxOpacity]);
+
+  if (reduceMotion) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className={cn("pointer-events-none absolute inset-0", className)}
+    />
+  );
+}

--- a/src/components/ui/magic/shine-border.stories.tsx
+++ b/src/components/ui/magic/shine-border.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ShineBorder } from "./shine-border";
+
+const meta = {
+  title: "Magic UI/ShineBorder",
+  component: ShineBorder,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof ShineBorder>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function CardStage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative w-80 overflow-hidden rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+      {children}
+      <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+        sample
+      </p>
+      <h3 className="mt-2 text-lg font-semibold leading-snug">
+        Quiet attention pull
+      </h3>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        ShineBorder draws a slow conic-gradient sweep around the parent
+        border. Use sparingly — at most one in view at a time.
+      </p>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <CardStage>
+      <ShineBorder borderRadius={8} />
+    </CardStage>
+  ),
+};
+
+export const Slow: Story = {
+  render: () => (
+    <CardStage>
+      <ShineBorder borderRadius={8} duration={28} />
+    </CardStage>
+  ),
+};
+
+export const ThickStroke: Story = {
+  render: () => (
+    <CardStage>
+      <ShineBorder borderRadius={8} borderWidth={2} duration={18} />
+    </CardStage>
+  ),
+};

--- a/src/components/ui/magic/shine-border.tsx
+++ b/src/components/ui/magic/shine-border.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+// Adapted from Magic UI · sprint-4 phase 4.4
+
+import { motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface ShineBorderProps {
+  /** Stroke width in px. Default: 1. */
+  borderWidth?: number;
+  /** Sweep duration in seconds. Default: 14. */
+  duration?: number;
+  /** Border-radius in px to match the parent. Default: 8. */
+  borderRadius?: number;
+  /** Highlight color (CSS color). Default: var(--ring). */
+  shineColor?: string;
+  className?: string;
+}
+
+/**
+ * Quieter cousin of `BorderBeam`: paints a slow conic-gradient sweep
+ * around its parent's border. Use sparingly on cards that earn a
+ * single attention pull (no more than one per viewport, per
+ * `docs/UI_LIBRARY_STRATEGY.md`).
+ *
+ * Place inside a `position: relative` parent. Becomes a static
+ * 1px border on `prefers-reduced-motion: reduce`.
+ */
+export function ShineBorder({
+  borderWidth = 1,
+  duration = 14,
+  borderRadius = 8,
+  shineColor = "var(--ring)",
+  className,
+}: ShineBorderProps) {
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) {
+    return (
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-[inherit]",
+          className,
+        )}
+        style={{
+          border: `${borderWidth}px solid color-mix(in srgb, ${shineColor} 30%, transparent)`,
+          borderRadius,
+        }}
+      />
+    );
+  }
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-0 rounded-[inherit]",
+        className,
+      )}
+      style={{
+        padding: borderWidth,
+        borderRadius,
+        // Mask out the inner area so only the border shows the gradient sweep.
+        WebkitMask:
+          "linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)",
+        WebkitMaskComposite: "xor",
+        mask: "linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)",
+        maskComposite: "exclude",
+      }}
+      initial={{ "--shine-angle": "0deg" } as never}
+      animate={{ "--shine-angle": "360deg" } as never}
+      // Linear keeps the sweep steady; motion's transition.ease cannot read CSS variables.
+      transition={{ duration, repeat: Infinity, ease: "linear" }}
+    >
+      <div
+        className="size-full rounded-[inherit]"
+        style={{
+          background: `conic-gradient(from var(--shine-angle, 0deg), transparent 0deg, ${shineColor} 60deg, transparent 120deg, transparent 360deg)`,
+        }}
+      />
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint 4 atmosphere push, phase 4 of 4 — final phase. Adds two Magic UI Wave 3 primitives, refreshes the Portal page so it no longer reads as a permanent placeholder, and polishes the resource card transition.

- **ShineBorder** Magic UI primitive (`src/components/ui/magic/shine-border.tsx`) — slow conic-gradient sweep around the parent's border via a CSS-mask ring overlay. Reduced-motion → static `color-mix(in srgb, var(--ring) 30%, transparent)` ring. One-per-viewport rule (`docs/UI_LIBRARY_STRATEGY.md`).
- **Particles** Magic UI primitive (`src/components/ui/magic/particles.tsx`) — canvas-based ambient drifting dots. rAF loop, `ResizeObserver` for fitting, `setTransform(1,0,0,1,0,0)` reset before each `scale(dpr, dpr)` so DPR transforms do not accumulate on resize. CSS-color resolution via a hidden DOM probe wrapped in `try/finally`. Reduced-motion → returns `null`.
- **Portal page refresh**:
  - `<Particles>` ambient layer behind the existing cyber-grid + noise + scanline atmosphere (one atmosphere layer per viewport, scoped to /portal only).
  - Prototype card wraps a `<ShineBorder borderRadius={12} duration={18} />` for a quiet attention pull.
  - Disabled "Kernel mode TBD" Button removed; CTAs are now translated `Link`s to `/projects` and `/`.
  - "Locked" framing dropped from `Portal.title` / `Portal.intro` — the page now reads as "atmosphere only", not a permanent placeholder.
- **Portal namespace expanded** in `messages/en.json` + `messages/zh.json` with `shellTitle`, `shellSubtitle`, `shellStatus`, `shellSlotStatus`, `shellSlot.{caseStudies,gallery,media}`, `shellFootnote`. CJK hand-translated.
- **ResourcePreviewCard** transition migrates from `transition-colors` to `transition-[border-color,transform,box-shadow]` so the existing `hover:-translate-y-0.5` actually animates instead of snapping; gains `hover:shadow-md hover:shadow-ring/5`.
- **Storybook**: `shine-border.stories.tsx` (Default, Slow, ThickStroke), `particles.stories.tsx` (Default, Dense, Slow).

## Test plan
- [x] `npm run lint` silent
- [x] `npm run typecheck` silent
- [ ] Vercel CI green (Snyk + Socket + production build)
- [ ] Manual smoke: `/en/portal` → particles drift slowly behind the prototype card; shine border draws around the card; CTAs navigate to /projects and /.
- [ ] Manual smoke: `/zh/portal` → same atmosphere, all copy reads in CJK.
- [ ] Manual smoke: `/en/resources` → resource cards lift smoothly on hover (transform now in transition list).
- [ ] DevTools `prefers-reduced-motion: reduce` → particles gone, shine static, card lift instant.
- [ ] DevTools window resize on /portal → particles do not accumulate scale (DPR reset in `fitCanvas`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)