### PR TITLE
chore: add validate + format:write npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lint": "eslint src .storybook tests next.config.ts playwright.config.ts",
     "typecheck": "tsc --noEmit --incremental false",
     "format": "prettier --check .",
+    "format:write": "prettier --write .",
+    "validate": "npm run lint && npm run typecheck",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test:e2e": "playwright test"


### PR DESCRIPTION
Tiny DX win.

- `npm run validate` aggregates lint + typecheck in one entry point.
- `npm run format:write` mirrors the existing read-only `format` (`prettier --check`).

No source changes. Mirrors the script set the upcoming PR-CI workflow (planned in Sprint 5.3) will invoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)