### PR TITLE
feat: phase-5.1 SEO foundations — sitemap, robots, hreflang on every route

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 import { PageShell } from "@/components/layout/page-shell"
 import { SectionHeading } from "@/components/sections/section-heading"
@@ -9,6 +10,21 @@ import { Stagger, StaggerItem } from "@/components/motion/stagger"
 import { profile } from "@/content/profile"
 import { Link } from "@/i18n/navigation"
 import type { Locale } from "@/i18n/routing"
+import { buildAlternates } from "@/lib/seo/alternates"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "About" })
+  return {
+    title: t("title"),
+    description: t("intro"),
+    alternates: buildAlternates(locale, "/about"),
+  }
+}
 
 export default async function AboutPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -6,6 +6,7 @@ import { PinnedPostCard } from "@/components/cards/pinned-post-card";
 import { FadeIn } from "@/components/motion/fade-in";
 import { posts } from "@/content/posts";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 import { BlogTimeline } from "./_client";
 
 export async function generateMetadata({
@@ -18,7 +19,7 @@ export async function generateMetadata({
   return {
     title: t("title"),
     description: t("metaDescription"),
-    alternates: { canonical: `/${locale}/blog` },
+    alternates: buildAlternates(locale, "/blog"),
   };
 }
 

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -6,7 +7,22 @@ import { ContentPendingLabel } from "@/components/placeholders/content-pending-l
 import { services } from "@/content/services";
 import { profile } from "@/content/profile";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 import { ContactForm } from "./_contact-form";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Contact",
+    description:
+      "Project inquiries and collaboration. Mailto and form fallback now, server-side provider later.",
+    alternates: buildAlternates(locale, "/contact"),
+  };
+}
 
 export default async function ContactPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;

--- a/src/app/[locale]/gallery/[collection]/page.tsx
+++ b/src/app/[locale]/gallery/[collection]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,12 +8,28 @@ import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
 import { EmptyArchiveState } from "@/components/placeholders/empty-archive-state";
 import { galleryCollections, galleryItems } from "@/content/gallery";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 export function generateStaticParams() {
   return galleryCollections.flatMap((collection) => [
     { locale: "en", collection: collection.slug },
     { locale: "zh", collection: collection.slug },
   ]);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale; collection: string }>;
+}): Promise<Metadata> {
+  const { locale, collection } = await params;
+  const item = galleryCollections.find((entry) => entry.slug === collection);
+  if (!item) return {};
+  return {
+    title: item.title,
+    description: item.description,
+    alternates: buildAlternates(locale, `/gallery/${collection}`),
+  };
 }
 
 export default async function GalleryCollectionPage({

--- a/src/app/[locale]/gallery/page.tsx
+++ b/src/app/[locale]/gallery/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { ArchiveCard } from "@/components/cards/archive-card"
 import { PageShell } from "@/components/layout/page-shell"
 import { SectionHeading } from "@/components/sections/section-heading"
@@ -6,7 +7,22 @@ import { FadeIn } from "@/components/motion/fade-in"
 import { Stagger, StaggerItem } from "@/components/motion/stagger"
 import { galleryCollections, galleryItems } from "@/content/gallery"
 import type { Locale } from "@/i18n/routing"
+import { buildAlternates } from "@/lib/seo/alternates"
 import { GalleryGrid } from "./_client"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  return {
+    title: "Gallery",
+    description:
+      "Black-and-white photography, digital art, and contact sheets — visual archive by ZhenXiao Mark Yu.",
+    alternates: buildAlternates(locale, "/gallery"),
+  }
+}
 
 export default async function GalleryPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params

--- a/src/app/[locale]/gallery/saved/layout.tsx
+++ b/src/app/[locale]/gallery/saved/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+// Saved frames are visitor-local state, not crawlable content.
+// `robots.ts` already disallows the path, but this `noindex` blocks
+// any inbound link from indexing the route on link signal alone.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function SavedLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/[locale]/games/[slug]/page.tsx
+++ b/src/app/[locale]/games/[slug]/page.tsx
@@ -15,6 +15,7 @@ import { CaseStudyFooter } from "@/components/case-study/case-study-footer";
 import { games } from "@/content/games";
 import type { Locale } from "@/i18n/routing";
 import { localize } from "@/lib/content/localize";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 export function generateStaticParams() {
   return games.flatMap((game) => [
@@ -35,7 +36,7 @@ export async function generateMetadata({
   return {
     title: localized.title,
     description: localized.pitch as string,
-    alternates: { canonical: `/${locale}/games/${slug}` },
+    alternates: buildAlternates(locale, `/games/${slug}`),
   };
 }
 

--- a/src/app/[locale]/games/page.tsx
+++ b/src/app/[locale]/games/page.tsx
@@ -8,6 +8,7 @@ import { FadeIn } from "@/components/motion/fade-in";
 import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import { games } from "@/content/games";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 import { localize } from "@/lib/content/localize";
 
 export async function generateMetadata({
@@ -21,7 +22,7 @@ export async function generateMetadata({
   return {
     title: tNav("games"),
     description: tGame("metaDescription"),
-    alternates: { canonical: `/${locale}/games` },
+    alternates: buildAlternates(locale, "/games"),
   };
 }
 

--- a/src/app/[locale]/media/page.tsx
+++ b/src/app/[locale]/media/page.tsx
@@ -8,11 +8,20 @@ import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
 import { MediaFrame } from "@/components/placeholders/media-frame";
 import { mediaItems } from "@/content/media";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 
-export const metadata: Metadata = {
-  title: "Media",
-  description: "Draft media and video archive for M4rkyu.com.",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Media",
+    description: "Video and process archive — draft frames hold the layout while final clips and posters land.",
+    alternates: buildAlternates(locale, "/media"),
+  };
+}
 
 export default async function MediaPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -30,6 +30,19 @@ import { games } from "@/content/games";
 import { mediaItems } from "@/content/media";
 import { profile } from "@/content/profile";
 import { localize } from "@/lib/content/localize";
+import { buildAlternates } from "@/lib/seo/alternates";
+import type { Metadata } from "next";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    alternates: buildAlternates(locale, ""),
+  };
+}
 
 export default async function HomePage({
   params,

--- a/src/app/[locale]/portal/page.tsx
+++ b/src/app/[locale]/portal/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { Terminal } from "lucide-react";
 import { PageShell } from "@/components/layout/page-shell";
@@ -8,6 +9,21 @@ import { Particles } from "@/components/ui/magic/particles";
 import { ShineBorder } from "@/components/ui/magic/shine-border";
 import { Link } from "@/i18n/navigation";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Portal" });
+  return {
+    title: t("title"),
+    description: t("intro"),
+    alternates: buildAlternates(locale, "/portal"),
+  };
+}
 
 const bootLines = [
   "> boot sequence: deferred",

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { allProjects, getProject } from "@/content/projects";
 import type { Locale } from "@/i18n/routing";
 import { Link } from "@/i18n/navigation";
 import { localize } from "@/lib/content/localize";
+import { buildAlternates } from "@/lib/seo/alternates";
 
 export function generateStaticParams() {
   return allProjects.flatMap((project) => [
@@ -36,7 +37,7 @@ export async function generateMetadata({
   return {
     title: project.seo.title,
     description: project.seo.description,
-    alternates: { canonical: `/${locale}/projects/${slug}` },
+    alternates: buildAlternates(locale, `/projects/${slug}`),
   };
 }
 

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { FadeIn } from "@/components/motion/fade-in"
 import { allProjects } from "@/content/projects"
 import type { Locale } from "@/i18n/routing"
+import { buildAlternates } from "@/lib/seo/alternates"
 import { ProjectsClient } from "./_client"
 
 export async function generateMetadata({
@@ -18,7 +19,7 @@ export async function generateMetadata({
   return {
     title: t("title"),
     description: t("intro"),
-    alternates: { canonical: `/${locale}/projects` },
+    alternates: buildAlternates(locale, "/projects"),
   }
 }
 

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -1,9 +1,25 @@
+import type { Metadata } from "next";
 import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { EmptyArchiveState } from "@/components/placeholders/empty-archive-state";
 import { resources } from "@/content/resources";
 import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
 import { ResourcesClient } from "./_client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: "Resources",
+    description:
+      "Tools, frameworks, and references — the small personal stack actually in use.",
+    alternates: buildAlternates(locale, "/resources"),
+  };
+}
 
 export default async function ResourcesPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono, Syne } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { SmoothScroll } from "@/providers/smooth-scroll";
+import { SITE_URL } from "@/lib/seo/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -22,7 +23,7 @@ const syne = Syne({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://www.m4rkyu.com"),
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "M4rkyu.com 2027",
     template: "%s | ZhenXiao Mark Yu",
@@ -42,7 +43,7 @@ export const metadata: Metadata = {
     title: "M4rkyu.com 2027",
     description:
       "Software engineering, game development, and digital art case studies by ZhenXiao Mark Yu.",
-    url: "https://www.m4rkyu.com",
+    url: SITE_URL,
   },
   twitter: {
     card: "summary_large_image",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { routing } from "@/i18n/routing";
+import { SITE_URL } from "@/lib/seo/site";
+
+export default function robots(): MetadataRoute.Robots {
+  // /<locale>/gallery/saved is visitor-local state (localStorage-driven)
+  // and not meaningful to crawl. Emit one explicit disallow per locale
+  // so non-Google crawlers (which often don't honor the leading-slash
+  // wildcard form) skip the path deterministically.
+  const savedPaths = routing.locales.map(
+    (locale) => `/${locale}/gallery/saved`,
+  );
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", ...savedPaths],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,77 @@
+import type { MetadataRoute } from "next";
+import { allProjects } from "@/content/projects";
+import { games } from "@/content/games";
+import { galleryCollections } from "@/content/gallery";
+import { routing, type Locale } from "@/i18n/routing";
+import { SITE_URL } from "@/lib/seo/site";
+
+// Stable timestamp computed at build time. Real `lastModified` per
+// entry will land when content data carries explicit dates;
+// returning `new Date()` per request makes crawlers think the whole
+// site refreshes every minute and they de-weight the signal.
+const BUILT_AT = new Date();
+
+const STATIC_PATHS = [
+  { path: "", changeFrequency: "weekly" as const, priority: 1.0 },
+  { path: "/projects", changeFrequency: "weekly" as const, priority: 0.9 },
+  { path: "/games", changeFrequency: "monthly" as const, priority: 0.8 },
+  { path: "/gallery", changeFrequency: "weekly" as const, priority: 0.8 },
+  { path: "/blog", changeFrequency: "weekly" as const, priority: 0.7 },
+  { path: "/media", changeFrequency: "monthly" as const, priority: 0.5 },
+  { path: "/resources", changeFrequency: "monthly" as const, priority: 0.6 },
+  { path: "/about", changeFrequency: "monthly" as const, priority: 0.7 },
+  { path: "/contact", changeFrequency: "yearly" as const, priority: 0.6 },
+  { path: "/portal", changeFrequency: "yearly" as const, priority: 0.4 },
+];
+
+function languageAlternates(path: string): Record<string, string> {
+  return Object.fromEntries(
+    routing.locales.map((locale) => [locale, `${SITE_URL}/${locale}${path}`]),
+  );
+}
+
+function entry(
+  path: string,
+  changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"],
+  priority: number,
+) {
+  const languages = languageAlternates(path);
+  return routing.locales.map<MetadataRoute.Sitemap[number]>(
+    (locale: Locale) => ({
+      url: `${SITE_URL}/${locale}${path}`,
+      lastModified: BUILT_AT,
+      changeFrequency,
+      priority,
+      alternates: { languages },
+    }),
+  );
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticEntries = STATIC_PATHS.flatMap(({ path, changeFrequency, priority }) =>
+    entry(path, changeFrequency, priority),
+  );
+
+  // Only include `ready` content in the sitemap so drafts and
+  // placeholders don't get crawled before they have real bodies.
+  const projectEntries = allProjects
+    .filter((project) => project.contentStatus === "ready")
+    .flatMap((project) => entry(`/projects/${project.slug}`, "monthly", 0.7));
+
+  const gameEntries = games
+    .filter((game) => game.status === "ready")
+    .flatMap((game) => entry(`/games/${game.slug}`, "monthly", 0.5));
+
+  const galleryEntries = galleryCollections
+    .filter((collection) => collection.status === "ready")
+    .flatMap((collection) =>
+      entry(`/gallery/${collection.slug}`, "monthly", 0.6),
+    );
+
+  return [
+    ...staticEntries,
+    ...projectEntries,
+    ...gameEntries,
+    ...galleryEntries,
+  ];
+}

--- a/src/lib/seo/alternates.ts
+++ b/src/lib/seo/alternates.ts
@@ -1,0 +1,26 @@
+import { routing, type Locale } from "@/i18n/routing";
+
+/**
+ * Build canonical + hreflang `alternates` for a per-route
+ * `generateMetadata` call.
+ *
+ * `path` is the locale-relative pathname starting with "/" (e.g.
+ * "/projects/nimbus"). The active locale's URL becomes the
+ * canonical; all routing locales are emitted as `languages` for
+ * `<link rel="alternate" hreflang="…">` tags. The active locale is
+ * intentionally included in `languages` — Google recommends a
+ * self-referential hreflang on every variant.
+ *
+ * Pass an empty string for the homepage.
+ */
+export function buildAlternates(
+  locale: Locale,
+  path: "" | `/${string}` = "",
+) {
+  return {
+    canonical: `/${locale}${path}`,
+    languages: Object.fromEntries(
+      routing.locales.map((entry) => [entry, `/${entry}${path}`]),
+    ) as Record<string, string>,
+  };
+}

--- a/src/lib/seo/site.ts
+++ b/src/lib/seo/site.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for the production canonical host.
+ *
+ * Used by `metadataBase` (root layout), `sitemap.ts`, and
+ * `robots.ts` so canonicals, hreflang alternates, and the sitemap
+ * always agree.
+ *
+ * NOTE on apex vs `www.`: as of 2026-05-09, both `m4rkyu.com` and
+ * `www.m4rkyu.com` serve content directly on Vercel (no host-level
+ * redirect). Google may pick either as canonical; we declare `www.`
+ * here to match historical OG / canonical signals already indexed.
+ * Resolving the duplicate-content concern is a Vercel domain-config
+ * task tracked separately — flip this constant to apex once the
+ * `www.` → apex 308 redirect is wired up at the platform level.
+ */
+export const SITE_URL = "https://www.m4rkyu.com";


### PR DESCRIPTION
Sprint 5 launch. Pure SEO/discoverability — no UI changes.

## Summary

- **`src/lib/seo/site.ts`** — single \`SITE_URL\` constant for \`metadataBase\`, sitemap, and robots so canonicals + hreflang + sitemap always agree. Documents the apex/www caveat: both currently serve directly on Vercel, flip the constant once a platform redirect is wired.
- **`src/lib/seo/alternates.ts`** — \`buildAlternates(locale, path)\` returns \`{ canonical, languages }\` with self-referential hreflang per Google's recommendation. \`path\` is typed \`\"\" | /\${string}\` to nudge callers toward the right shape.
- **`src/app/sitemap.ts`** — emits one URL per (route, locale) pair with hreflang \`languages\`. Static paths for every top-level page; dynamic paths only for \`ready\` projects, games, and gallery collections (drafts excluded). Single build-time \`lastModified\` so crawlers don't see \"everything changed every minute\".
- **`src/app/robots.ts`** — allows \`/\`, disallows \`/api/\` and an explicit \`/<locale>/gallery/saved\` per locale (driven by \`routing.locales\`) so non-Google crawlers without leading-slash wildcard support honor the exclusion.
- **`src/app/[locale]/gallery/saved/layout.tsx`** — \`robots: { index: false, follow: false }\` so any inbound link can't index the user-state route on link signal alone.
- **Per-page metadata audit**:
  - Pages with existing canonical (projects, project slug, games, game slug, blog) now also emit hreflang via \`buildAlternates\`.
  - Pages missing metadata entirely (about, contact, gallery, gallery collection, portal, resources) gain a new \`generateMetadata\` with title + description + \`buildAlternates\`.
  - \`media\`: static \`metadata\` const → \`generateMetadata\` so the locale param flows through.
  - homepage \`[locale]/page.tsx\`: \`generateMetadata\` returning only \`alternates\` so per-locale canonical overrides the root layout's static \`/en\` canonical.

## Out of scope (intentional)

- **Apex vs www host canonicalization** — both \`m4rkyu.com\` and \`www.m4rkyu.com\` currently serve directly. SEO stack is consistent at the code level via \`SITE_URL\`; the platform-level redirect is a Vercel domain-config task.
- **Localized titles/descriptions** for \`about\`, \`contact\`, \`gallery\`, \`media\`, \`resources\`, \`portal\` — currently English only on \`/zh\` routes for those four. Adding translation keys is a small follow-up; the canonical/hreflang fix is the load-bearing part.
- **Per-route \`opengraph-image.tsx\`** — Phase 5.2.

## Test plan

- [x] \`npm run validate\` silent (lint + typecheck)
- [ ] Vercel CI green (Snyk + Socket + production build + Playwright)
- [ ] After preview deploys: \`curl <preview>/sitemap.xml\` → 200, contains \`hreflang\` alternates per URL
- [ ] \`curl <preview>/robots.txt\` → contains \`Sitemap:\` directive + locale-explicit \`Disallow: /en/gallery/saved\` and \`/zh/gallery/saved\`
- [ ] View source on \`/en/projects/nimbus\` → \`<link rel=\"canonical\" href=\".../en/projects/nimbus\">\` + \`<link rel=\"alternate\" hreflang=\"zh\" href=\".../zh/projects/nimbus\">\`
- [ ] View source on \`/en/gallery/saved\` → \`<meta name=\"robots\" content=\"noindex, nofollow\">\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)