### PR TITLE
feat: phase-5.2 next/og per-route OG images (Latin-only first pass)

### DIFF
--- a/src/app/[locale]/games/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/games/[slug]/opengraph-image.tsx
@@ -1,0 +1,42 @@
+import { notFound } from "next/navigation";
+import {
+  OG_CONTENT_TYPE,
+  OG_IMAGE_SIZE,
+  renderOgImage,
+} from "@/lib/seo/og-image";
+import { games, getGame } from "@/content/games";
+import { routing } from "@/i18n/routing";
+
+export const runtime = "edge";
+export const alt = "Game archive entry — M4rkyu.com";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+// Same Latin-only constraint as the project OG: next/og's default
+// font does not cover CJK, so the same render is reused per locale.
+export function generateImageMetadata() {
+  return games.flatMap((game) =>
+    routing.locales.map((locale) => ({
+      id: `${locale}-${game.slug}`,
+      alt: `${game.title} — game archive`,
+      contentType: OG_CONTENT_TYPE,
+      size: OG_IMAGE_SIZE,
+    })),
+  );
+}
+
+export default async function OpengraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const game = getGame(slug);
+  if (!game) notFound();
+  return renderOgImage({
+    eyebrow: "GAME ARCHIVE",
+    title: game.title,
+    subtitle: game.pitch,
+    footer: `m4rkyu.com / games / ${game.slug}`,
+  });
+}

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,22 @@
+import {
+  OG_CONTENT_TYPE,
+  OG_IMAGE_SIZE,
+  renderOgImage,
+} from "@/lib/seo/og-image";
+
+export const runtime = "edge";
+export const alt = "M4rkyu.com — software, games, art";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+// OG content is Latin-only because next/og's default font does not
+// cover CJK glyphs. Both /en and /zh share the same image; the
+// expanded social card lands the visitor on the correct locale.
+export default async function OpengraphImage() {
+  return renderOgImage({
+    eyebrow: "M4RKYU.COM · 2027",
+    title: "Software · Games · Digital Art",
+    subtitle:
+      "ZhenXiao Mark Yu — engineering, game development, and visual systems.",
+  });
+}

--- a/src/app/[locale]/projects/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/projects/[slug]/opengraph-image.tsx
@@ -1,0 +1,44 @@
+import { notFound } from "next/navigation";
+import {
+  OG_CONTENT_TYPE,
+  OG_IMAGE_SIZE,
+  renderOgImage,
+} from "@/lib/seo/og-image";
+import { allProjects, getProject } from "@/content/projects";
+import { routing } from "@/i18n/routing";
+
+export const runtime = "edge";
+export const alt = "Case study — M4rkyu.com";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+// Pre-declare one OG per (locale, slug) so Next can statically
+// generate at build time. The image content itself is Latin-only
+// (next/og default font lacks CJK), so the same render is reused
+// regardless of locale.
+export function generateImageMetadata() {
+  return allProjects.flatMap((project) =>
+    routing.locales.map((locale) => ({
+      id: `${locale}-${project.slug}`,
+      alt: `${project.title} — case study`,
+      contentType: OG_CONTENT_TYPE,
+      size: OG_IMAGE_SIZE,
+    })),
+  );
+}
+
+export default async function OpengraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const project = getProject(slug);
+  if (!project) notFound();
+  return renderOgImage({
+    eyebrow: "PROJECT · CASE STUDY",
+    title: project.title,
+    subtitle: project.shortPitch,
+    footer: `m4rkyu.com / projects / ${project.slug}`,
+  });
+}

--- a/src/content/games.ts
+++ b/src/content/games.ts
@@ -47,3 +47,7 @@ export const games = [
     ],
   },
 ].map((game) => gameSchema.parse(game));
+
+export function getGame(slug: string) {
+  return games.find((game) => game.slug === slug);
+}

--- a/src/lib/seo/og-image.tsx
+++ b/src/lib/seo/og-image.tsx
@@ -1,0 +1,182 @@
+import { ImageResponse } from "next/og";
+
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
+export const OG_CONTENT_TYPE = "image/png";
+export const OG_FOOTER_TAG = "ZX MARK YU · 2027";
+
+interface OgImageProps {
+  /** Mono uppercase eyebrow above the title (e.g. "case study"). */
+  eyebrow: string;
+  /** Large display-font title. */
+  title: string;
+  /** Muted subtitle / lede beneath the title. Optional. */
+  subtitle?: string;
+  /** Footer line (e.g. domain or section path). Defaults to the site URL. */
+  footer?: string;
+}
+
+const BG = "#070707";
+const FG = "#f7f7f7";
+const MUTED = "#9a9a9a";
+const RING = "#67e8f9";
+const BORDER = "#27272a";
+
+// Heuristic: shrink the title font when it's long. CJK glyphs are
+// visually ~1.7× wider than Latin, so we count them weighted.
+function effectiveLength(value: string): number {
+  let length = 0;
+  for (const ch of value) {
+    length += /[㐀-鿿豈-﫿　-〿]/.test(ch) ? 1.7 : 1;
+  }
+  return length;
+}
+
+/**
+ * Renders a 1200×630 OG image with the site's editorial vocabulary:
+ * dark background, cyber-grid wash, mono eyebrow, large display
+ * title, ring-color underline accent, mono footer.
+ *
+ * `next/og` runs Satori, which supports a subset of CSS via inline
+ * `style` only (no Tailwind classes). All values are literal hex/px
+ * so SSR + Edge runtime evaluate cleanly.
+ *
+ * Note: this renderer ships with `next/og`'s default Latin font
+ * only — no CJK font is bundled. Callers should keep `title` /
+ * `subtitle` content in Latin script. Mixing in CJK characters
+ * will render as tofu boxes until a font is wired in.
+ */
+export function renderOgImage({
+  eyebrow,
+  title,
+  subtitle,
+  footer = "m4rkyu.com",
+}: OgImageProps): ImageResponse {
+  const len = effectiveLength(title);
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: BG,
+          color: FG,
+          padding: "72px 80px",
+          fontFamily: "ui-sans-serif, system-ui, sans-serif",
+          position: "relative",
+        }}
+      >
+        {/* Cyber-grid wash via two repeating linear gradients. */}
+        <div
+          style={{
+            display: "flex",
+            position: "absolute",
+            inset: 0,
+            backgroundImage: `linear-gradient(${BORDER} 1px, transparent 1px), linear-gradient(90deg, ${BORDER} 1px, transparent 1px)`,
+            backgroundSize: "60px 60px, 60px 60px",
+            opacity: 0.45,
+          }}
+        />
+        {/* Subtle accent wash toward the bottom. Satori's radial
+         * support is partial; a top-to-bottom linear gradient
+         * fades cleanly to a soft ring tint above the footer. */}
+        <div
+          style={{
+            display: "flex",
+            position: "absolute",
+            inset: 0,
+            backgroundImage: `linear-gradient(to bottom, transparent 55%, rgba(103, 232, 249, 0.12) 100%)`,
+          }}
+        />
+        {/* Top eyebrow row. */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            fontSize: 22,
+            letterSpacing: 6,
+            textTransform: "uppercase",
+            color: MUTED,
+            zIndex: 1,
+          }}
+        >
+          <span
+            style={{
+              display: "inline-block",
+              height: 1,
+              width: 56,
+              background: BORDER,
+            }}
+          />
+          {eyebrow}
+        </div>
+
+        {/* Title block. */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 28,
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontSize: len > 48 ? 80 : len > 24 ? 96 : 112,
+              fontWeight: 700,
+              lineHeight: 1.02,
+              letterSpacing: -2,
+              color: FG,
+              maxWidth: 1040,
+            }}
+          >
+            {title}
+          </div>
+          {subtitle ? (
+            <div
+              style={{
+                fontSize: 32,
+                lineHeight: 1.32,
+                color: MUTED,
+                maxWidth: 880,
+              }}
+            >
+              {subtitle}
+            </div>
+          ) : null}
+          <div
+            style={{
+              height: 2,
+              width: 96,
+              background: RING,
+              opacity: 0.65,
+            }}
+          />
+        </div>
+
+        {/* Footer row. */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            fontSize: 22,
+            letterSpacing: 4,
+            textTransform: "uppercase",
+            color: MUTED,
+            zIndex: 1,
+          }}
+        >
+          <span>{footer}</span>
+          <span>{OG_FOOTER_TAG}</span>
+        </div>
+      </div>
+    ),
+    OG_IMAGE_SIZE,
+  );
+}


### PR DESCRIPTION
Sprint 5 phase 2 — pure SEO/social-share, no UI changes.

## Summary

- **`src/lib/seo/og-image.tsx`** — shared `renderOgImage` helper. Returns a 1200×630 \`next/og\` ImageResponse with the editorial vocabulary: dark \`#070707\` ground, cyber-grid wash via two repeating linear-gradients at 60px, soft ring-tinted bottom fade (linear, not radial — Satori's radial support is partial), mono uppercase eyebrow with horizontal rule, large display title (font-size scales by *effective* length — CJK glyphs weighted 1.7×), optional muted subtitle, ring-color underline accent, mono footer with site URL + author tag (\`OG_FOOTER_TAG\` constant). All styles inline (Satori subset). Defensive \`display: flex\` on absolute background divs.
- **`src/app/[locale]/opengraph-image.tsx`** — root locale OG. Latin-only content shared across /en and /zh.
- **`src/app/[locale]/projects/[slug]/opengraph-image.tsx`** — per-project OG. \`generateImageMetadata\` pre-declares one image per (locale, slug) so Next statically pre-renders.
- **`src/app/[locale]/games/[slug]/opengraph-image.tsx`** — same shape, parity with projects.
- New \`getGame(slug)\` in \`src/content/games.ts\` mirrors \`getProject()\` so OG routes share a centralized 404 path.

## CJK constraint (intentional, in-scope)

\`next/og\`'s default font does not cover CJK. Bundling a subset Noto Sans SC font is a follow-up; for now zh OG images use Latin content. Social-card readers still land the visitor on the correct localized route — this only affects the preview thumbnail.

## Test plan

- [x] \`npm run validate\` silent (lint + typecheck)
- [ ] Vercel CI green (Snyk + Socket + production build)
- [ ] After preview deploys: \`curl -I <preview>/en/opengraph-image\` → 200 with \`Content-Type: image/png\`
- [ ] Visit \`<preview>/en/projects/nimbus/opengraph-image\` directly → renders editorial card
- [ ] Visit \`<preview>/en/games/descent-into-madness/opengraph-image\` → renders editorial card
- [ ] View source on \`/en/projects/nimbus\` → \`<meta property=\"og:image\" content=\".../en/projects/nimbus/opengraph-image\">\`
- [ ] Twitter / LinkedIn link-preview tools render the correct per-route card

🤖 Generated with [Claude Code](https://claude.com/claude-code)