### PR TITLE
chore: phase-5.4 content summary helper + tighter Zod hygiene

### DIFF
--- a/src/app/[locale]/games/page.tsx
+++ b/src/app/[locale]/games/page.tsx
@@ -10,6 +10,7 @@ import { games } from "@/content/games";
 import type { Locale } from "@/i18n/routing";
 import { buildAlternates } from "@/lib/seo/alternates";
 import { localize } from "@/lib/content/localize";
+import { summarize } from "@/lib/content/summary";
 
 export async function generateMetadata({
   params,
@@ -34,8 +35,9 @@ export default async function GamesPage({
   const { locale } = await params;
   const tNav = await getTranslations({ locale, namespace: "Navigation" });
   const tGame = await getTranslations({ locale, namespace: "Game" });
-  const readyCount = games.filter((g) => g.status === "ready").length;
-  const draftCount = games.length - readyCount;
+  const summary = summarize(games);
+  const readyCount = summary.ready;
+  const draftCount = summary.total - summary.ready;
 
   return (
     <PageShell locale={locale}>

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -7,6 +7,7 @@ import { FadeIn } from "@/components/motion/fade-in"
 import { allProjects } from "@/content/projects"
 import type { Locale } from "@/i18n/routing"
 import { buildAlternates } from "@/lib/seo/alternates"
+import { summarize } from "@/lib/content/summary"
 import { ProjectsClient } from "./_client"
 
 export async function generateMetadata({
@@ -30,8 +31,9 @@ export default async function ProjectsPage({
 }) {
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: "Projects" })
-  const readyCount = allProjects.filter((p) => p.contentStatus === "ready").length
-  const draftCount = allProjects.length - readyCount
+  const summary = summarize(allProjects, (p) => p.contentStatus)
+  const readyCount = summary.ready
+  const draftCount = summary.total - summary.ready
 
   return (
     <PageShell locale={locale}>

--- a/src/content/schemas.ts
+++ b/src/content/schemas.ts
@@ -1,21 +1,26 @@
 import { z } from "zod";
 
+// `min(1)` on required strings so empty data fails the Zod parse at
+// build time rather than silently rendering a blank line. Optional
+// fields stay loose; `contentStatusSchema` already gates whether a
+// page is real or placeholder.
+
 export const seoSchema = z.object({
-  title: z.string(),
-  description: z.string(),
+  title: z.string().min(1),
+  description: z.string().min(1),
 });
 
 export const imageSchema = z.object({
-  src: z.string(),
-  alt: z.string(),
+  src: z.string().min(1),
+  alt: z.string().min(1),
 });
 
 export const contentStatusSchema = z.enum(["ready", "draft", "placeholder", "coming-soon"]);
 
 export const projectSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
-  shortPitch: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  shortPitch: z.string().min(1),
   category: z.enum([
     "web-app",
     "game-dev",
@@ -24,21 +29,25 @@ export const projectSchema = z.object({
     "experiment",
     "maintenance",
   ]),
-  year: z.string(),
+  year: z.string().min(1),
   status: z.enum(["ready", "development", "maintenance", "archived", "draft"]),
   contentStatus: contentStatusSchema.default("draft"),
   featured: z.boolean(),
-  problem: z.string(),
-  solution: z.string(),
-  role: z.string(),
+  problem: z.string().min(1),
+  solution: z.string().min(1),
+  role: z.string().min(1),
   stack: z.array(z.string()),
   features: z.array(z.string()),
   architectureNotes: z.array(z.string()),
-  challenges: z.array(z.string()).default(["TBD: replace with final challenge notes."]),
+  // No "TBD…" default — an empty array reads as "no challenges yet"
+  // and the page section collapses cleanly. Inventing placeholder
+  // copy here would inject fake content into every project that
+  // forgot to author this field.
+  challenges: z.array(z.string()).default([]),
   screenshots: z.array(imageSchema).default([]),
   liveUrl: z.string().url().optional(),
   githubUrl: z.string().url().optional(),
-  outcome: z.string(),
+  outcome: z.string().min(1),
   lessonsLearned: z.array(z.string()),
   nextSteps: z.array(z.string()),
   seo: seoSchema,
@@ -71,9 +80,9 @@ export const galleryAspectSchema = z.enum([
 ]);
 
 export const galleryCollectionSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
-  description: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  description: z.string().min(1),
   cover: imageSchema.extend({
     focal: z.enum(["top", "center", "bottom"]).default("center"),
   }),
@@ -87,12 +96,12 @@ export const galleryCollectionSchema = z.object({
 });
 
 export const galleryItemSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
-  collection: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  collection: z.string().min(1),
   type: z.enum(["image", "contact-sheet", "process"]),
   status: contentStatusSchema,
-  caption: z.string(),
+  caption: z.string().min(1),
   src: imageSchema.optional(),
   aspect: galleryAspectSchema.default("4/5"),
   capturedAt: z.string().optional(),
@@ -105,24 +114,24 @@ export const galleryItemSchema = z.object({
 });
 
 export const resourceSchema = z.object({
-  name: z.string(),
-  slug: z.string(),
-  category: z.string(),
-  description: z.string(),
-  why: z.string(),
+  name: z.string().min(1),
+  slug: z.string().min(1),
+  category: z.string().min(1),
+  description: z.string().min(1),
+  why: z.string().min(1),
   link: z.string().url(),
-  pricing: z.string(),
+  pricing: z.string().min(1),
   tags: z.array(z.string()),
   status: contentStatusSchema.default("placeholder"),
 });
 
 export const postSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
-  category: z.string(),
-  excerpt: z.string(),
-  date: z.string(),
-  readingTime: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  category: z.string().min(1),
+  excerpt: z.string().min(1),
+  date: z.string().min(1),
+  readingTime: z.string().min(1),
   tags: z.array(z.string()),
   status: contentStatusSchema,
   // Phase 1.5 additions
@@ -141,13 +150,13 @@ export const postsArraySchema = z.array(postSchema).superRefine((arr, ctx) => {
 });
 
 export const gameSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
-  engine: z.string(),
-  year: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  engine: z.string().min(1),
+  year: z.string().min(1),
   status: contentStatusSchema,
-  pitch: z.string(),
-  role: z.string(),
+  pitch: z.string().min(1),
+  role: z.string().min(1),
   notes: z.array(z.string()),
   // Phase 1.3 additions — all optional / defaulted so existing content validates.
   cover: imageSchema.optional(),
@@ -166,18 +175,18 @@ export const gameSchema = z.object({
 });
 
 export const mediaItemSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
   format: z.enum(["video", "reel", "process", "poster"]),
   status: contentStatusSchema,
-  description: z.string(),
+  description: z.string().min(1),
   duration: z.string().optional(),
 });
 
 export const serviceSchema = z.object({
-  title: z.string(),
-  slug: z.string(),
-  description: z.string(),
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  description: z.string().min(1),
   fit: z.array(z.string()),
   status: contentStatusSchema,
 });

--- a/src/lib/content/summary.ts
+++ b/src/lib/content/summary.ts
@@ -1,0 +1,45 @@
+import type { z } from "zod";
+import { contentStatusSchema } from "@/content/schemas";
+
+export type ContentStatus = z.infer<typeof contentStatusSchema>;
+
+export interface ContentSummary {
+  total: number;
+  ready: number;
+  draft: number;
+  placeholder: number;
+  comingSoon: number;
+}
+
+/**
+ * Count items by `contentStatus`/`status` across any content
+ * collection that conforms to the shared `contentStatusSchema`.
+ *
+ * Pass an explicit `getStatus` selector when the collection's
+ * status field isn't named `status` (e.g. projects use
+ * `contentStatus`).
+ *
+ * Replaces ad-hoc per-page filters like
+ * `games.filter(g => g.status === "ready").length`.
+ */
+export function summarize<T>(
+  items: readonly T[],
+  getStatus: (item: T) => ContentStatus = (item) =>
+    (item as { status: ContentStatus }).status,
+): ContentSummary {
+  const summary: ContentSummary = {
+    total: items.length,
+    ready: 0,
+    draft: 0,
+    placeholder: 0,
+    comingSoon: 0,
+  };
+  for (const item of items) {
+    const status = getStatus(item);
+    if (status === "ready") summary.ready += 1;
+    else if (status === "draft") summary.draft += 1;
+    else if (status === "placeholder") summary.placeholder += 1;
+    else if (status === "coming-soon") summary.comingSoon += 1;
+  }
+  return summary;
+}


### PR DESCRIPTION
Sprint 5 phase 4 — pure content-layer hygiene, no UI changes.

## Summary

- **`src/lib/content/summary.ts`** — \`summarize(items, getStatus?)\` returns \`{ total, ready, draft, placeholder, comingSoon }\` for any collection conforming to \`contentStatusSchema\`. Optional selector for collections whose status field isn't named \`status\` (e.g. projects use \`contentStatus\`).
- Wired into the games + projects archive pages — the two places that computed \`readyCount\`/\`draftCount\` manually for the archive status block.
- **Zod tightening** across \`src/content/schemas.ts\`:
  - All previously-required string fields → \`z.string().min(1)\` so empty data fails the parse at build time rather than rendering a silent blank line.
  - Optional fields stay loose; \`contentStatusSchema\` continues to gate whether a page is real or placeholder.
  - **\`projectSchema.challenges\` default dropped** from \`["TBD: replace…"]\` to \`[]\`. The previous default was injecting fake placeholder copy into every project that forgot to author challenges. An empty array reads as "no challenges yet" and the page section collapses cleanly — consistent with the CLAUDE.md \"no fake content\" rule.

## Test plan

- [x] \`npm run validate\` silent (lint + typecheck)
- [ ] Vercel CI green (Snyk + Socket + production build) — build will exercise every \`schema.parse()\` call
- [ ] Playwright smoke green — boots dev server which imports content modules
- [ ] Manual: \`/en/projects\` and \`/en/games\` — archive status blocks read the same numbers as before; no \"TBD: replace with final challenge notes\" appears anywhere a project never set \`challenges\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)