### PR TITLE
docs: phase-5.5 cleanup + vibe-coding playbook + design doc refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ The legacy Vite + React 18 site that previously held this domain has been
 archived to [zhenxiao-yu/m4rkyu-archive](https://github.com/zhenxiao-yu/m4rkyu-archive)
 and is reachable on a free `*.vercel.app` URL for rollback.
 
+> **First time contributing (human or AI)?** Start with
+> [docs/AI_WORKFLOW.md](docs/AI_WORKFLOW.md) — it documents the
+> one-PR-per-phase cadence, validation gate, code-reviewer
+> subagent contract, and the cross-cutting rules learned during
+> the redesign.
+
 ## Stack
 
 - Next.js App Router with locale routes for `/en` and `/zh`.
@@ -36,6 +42,7 @@ npm run dev -- --hostname 127.0.0.1 --port 3000
 
 ```bash
 npm audit --audit-level=moderate
+npm run validate            # lint + typecheck (aggregate)
 npm run lint
 npm run typecheck
 npm run build
@@ -47,10 +54,38 @@ npm run test:e2e
 `NEXT_DIST_DIR=.next-playwright` and checks the route matrix across 360, 390,
 768, 1280, 1920, and desktop Chromium widths.
 
+## CI
+
+- **`.github/workflows/pr.yml`** runs `npm run validate` (lint + typecheck) and
+  the Playwright smoke spec on every pull request. Merges are blocked on
+  either failing.
+- **`.github/workflows/release.yml`** runs the full validation suite on tag
+  pushes (`v*.*.*`) and creates the GitHub release.
+- Vercel handles the production build + per-PR preview deploys; Snyk + Socket
+  gate dependency security.
+
 ## Deployment
 
 `main` auto-deploys to the `m4rkyu-portfolio` Vercel project, which serves
 `m4rkyu.com` and `www.m4rkyu.com` from the latest production build.
+
+## SEO
+
+- `src/app/sitemap.ts` and `src/app/robots.ts` generate `/sitemap.xml` and
+  `/robots.txt`. Only `ready` content lands in the sitemap; drafts are excluded.
+- `src/lib/seo/site.ts` is the single source of truth for the canonical host
+  used by `metadataBase`, sitemap, and robots.
+- `src/lib/seo/alternates.ts` builds canonical + hreflang `languages` for every
+  per-route `generateMetadata` call.
+- `src/lib/seo/og-image.tsx` plus `opengraph-image.tsx` route handlers under
+  `[locale]`, `[locale]/projects/[slug]`, and `[locale]/games/[slug]` produce
+  per-route 1200×630 social cards via `next/og`.
+
+## Working with AI agents
+
+See [docs/AI_WORKFLOW.md](docs/AI_WORKFLOW.md) for the
+one-PR-per-phase cadence, code-reviewer subagent gate, validation contract,
+and the cross-cutting rules learned during the redesign.
 
 ## Content Safety
 

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -1,0 +1,223 @@
+---
+title: M4rkyu.com — AI / vibe-coding workflow
+status: living
+audience: future contributors (human + AI)
+last_updated: 2026-05-10
+---
+
+# AI / vibe-coding workflow
+
+This file documents the working contract used while shipping the
+2027 redesign — five sprints, 24 PRs (#12–#35), dark/light themes,
+Cmd-K palette, sitemap + per-route OG. It is a playbook, not a
+rulebook. Future contributors (Claude, human, or otherwise)
+should keep it accurate when they change the cadence.
+
+---
+
+## 1. One PR per phase
+
+Every phase ships as a single squash-merged PR off `main`.
+
+- Branch name: `<kind>/phase-<N.M>-<short-tag>`. `kind` is one of
+  `feat` (new visible behavior), `polish` (visual / UX without
+  semantic change), `chore` (infra, scripts, docs, content
+  hygiene), `fix`.
+- Commit message + PR title share the same line. Body explains
+  *why* the change exists, scoped per phase.
+- One concern per PR. If a code-review finding lands a refactor
+  that's worth doing, file it as the next phase, not as a tag-along
+  in the current PR.
+
+This cadence is what kept the redesign reviewable. A 25-PR squash
+log reads as a sprint timeline; a "big-bang" branch would read as
+a wall.
+
+---
+
+## 2. The cross-cutting rules
+
+Pulled from `~/.claude/projects/h--Github-M4rkyu-com/memory/feedback_phase1_patterns.md`.
+These are hard-won, not stylistic.
+
+- **Translations from line one.** Every visible string routes
+  through `next-intl`. CJK is hand-translated, not transliterated.
+  Adding a string in English-only is technical debt that always
+  has to be repaid.
+- **Drop `locale` props that aren't used.** `next-intl`'s `Link`
+  resolves locale from context.
+- **`aria-hidden="true"` on every decorative icon.** lucide icons
+  default to `role="img"`.
+- **Tokens only.** `var(--ring)`, `var(--motion-fast)`,
+  `var(--ease-premium)`, `border-border`, `bg-card`, `bg-muted`.
+  No `bg-zinc-*`, no hex literals, no
+  `transition-[colors,transform]` (invalid Tailwind 4).
+- **Hardcoded easings inside `motion/react`** get an inline
+  carve-out comment — `transition.ease` cannot read CSS variables.
+- **`Button` variants**: `default | secondary | outline | ghost |
+  link`. No `destructive` variant.
+- **External `<a>` carries `rel="noopener noreferrer"`**.
+- **Do not touch `next.config.ts`, `package.json`,
+  `package-lock.json`, `tsconfig.json`** unless the phase
+  explicitly does. This kept the build environment stable across
+  25 PRs.
+- **`prefers-reduced-motion` honored on every animated primitive**
+  via `useReducedMotion()` from `motion/react`. Touch surfaces
+  short-circuit pointer-tracking effects via
+  `matchMedia("(pointer: fine)")`.
+
+---
+
+## 3. Validation gate
+
+Before pushing any PR:
+
+```bash
+npm run validate    # lint + typecheck
+```
+
+Both must be silent. Local `npm run build` hits a known Windows
+EISDIR issue — Vercel CI on Linux is the source of truth for the
+production build. The PR CI workflow
+(`.github/workflows/pr.yml`) runs `validate` plus the Playwright
+smoke spec on every PR; merges are blocked on either failing.
+
+If validate is silent but the PR CI Playwright job fails, **read
+the failure carefully**. The new PR CI in Phase 5.3 caught a stale
+test selector on its very first run — that is the gate doing its
+job.
+
+---
+
+## 4. Code-reviewer subagent gate
+
+Every PR runs through the `code-reviewer` subagent before commit:
+
+```
+Task → subagent_type: code-reviewer
+       prompt: branch + scope + files + constraints
+```
+
+The subagent reports **BLOCK** / **SHOULD-FIX** / **NIT** with
+file:line references.
+
+- **BLOCK**: must fix before commit. Hydration mismatches, broken
+  a11y, leaked secrets, etc.
+- **SHOULD-FIX**: address unless there's a documented reason
+  (note in the PR description).
+- **NIT**: optional, judgment call.
+
+The subagent is opinionated and sometimes wrong. The reviewer's
+report is *input* — the implementing agent verifies before
+applying. Several phases this round flagged-and-pushed-back on
+NIT-level items; that's healthy.
+
+---
+
+## 5. Plan files + memory
+
+Two persistent stores guide multi-session work:
+
+- **Plan file** — when running an agent in plan mode, the agent
+  writes a per-task plan that survives across sessions. Path
+  varies per harness; it's the single source of truth for "what's
+  the next sprint and why".
+- **Memory** at
+  `~/.claude/projects/h--Github-M4rkyu-com/memory/`. Saves
+  hard-won feedback patterns, project context, references — facts
+  that should outlive a single conversation.
+
+The memory has guardrails (see the `auto memory` section of the
+**user's global** `~/.claude/CLAUDE.md`, not this repo's
+`CLAUDE.md`): never duplicate code patterns the codebase already
+encodes; index entries through `MEMORY.md`; verify a recalled
+memory is still true before acting on it.
+
+---
+
+## 6. Background tasks + concurrency
+
+PR CI takes 3–5 minutes. Spawn the wait as a background command
+(harness pseudocode, not a runnable script):
+
+```text
+Bash({
+  command: `until gh pr checks <N> 2>&1 | grep -qE "fail|pass" && \
+           ! gh pr checks <N> 2>&1 | grep -q "pending"; do sleep 25; done; \
+           gh pr checks <N> 2>&1`,
+  run_in_background: true
+})
+```
+
+The runtime sends a notification when the loop exits. Use the
+window in between to draft the next phase's plan or read context
+for the next branch — but **don't open a second branch on top of
+unmerged work**. Cleanly merge → branch off `main` → next phase.
+
+Never poll in a tight loop with multiple `sleep` chains — the
+harness blocks that. One background `until` loop, one
+notification.
+
+---
+
+## 7. Subagent fan-out
+
+Three subagents earned their keep this redesign:
+
+- **`code-reviewer`** — pre-commit gate. See §4.
+- **`Explore`** — open-ended file discovery. Use when the scope
+  spans multiple areas or the file path isn't known.
+- **`general-purpose`** with model override — mechanical work
+  that doesn't need Opus. Sprint 3.1's Tailwind-canonical-class
+  sweep (PR #23) delegated to a Haiku-backed subagent — fast,
+  cheap, accurate.
+
+Avoid spawning multiple subagents for the same question — pick
+the most-specialized one for the job and trust its output.
+
+---
+
+## 8. Asking for clarification
+
+A clarifying question to the user has a real cost — it interrupts
+flow. Spend up to a minute on read-only investigation
+(grep, file reads, memory) so the question becomes specific:
+"Found Cmd-K trigger A and B in the header — which one should
+the icon variant inherit from?" beats "where is the trigger?".
+
+For broader direction questions ("which polish target should
+Sprint 4 prioritize?") the `AskUserQuestion` tool with structured
+options is the right form. For yes/no inside a session that's
+already moving, output a short message and continue.
+
+---
+
+## 9. What's in scope for "vibe coding"
+
+For this codebase, vibe coding means:
+
+- The user describes intent ("polish the header", "Sprint 5 SEO")
+  and accepts course corrections mid-PR.
+- The agent owns: scope, branching, code-reviewer pass, lint /
+  typecheck gate, commit message, PR body, CI watch, merge.
+- The agent does not own: hard tradeoffs (apex vs www domain
+  routing, brand vocabulary changes, deferred feature unlocks).
+  Those route through a clarifying question or a plan file.
+- "Auto mode" toggles whether the agent stops to ask each step —
+  not whether the agent owns harder calls. Even in auto mode,
+  destructive ops (`git reset --hard`, force-push, deleting
+  shared infra) still require explicit user approval.
+
+---
+
+## 10. When the playbook breaks
+
+If a step here is wrong for the situation:
+
+1. Note it in the PR description ("departing from §3 because…").
+2. After the PR ships, edit this file in a follow-up commit.
+3. If the change reveals a pattern other contributors will hit,
+   add a memory entry under `feedback_*.md`.
+
+Don't silently break the contract — document the exception, then
+update the contract.

--- a/docs/COMPONENT_MAP.md
+++ b/docs/COMPONENT_MAP.md
@@ -1,11 +1,18 @@
 ---
 title: M4rkyu.com — Component Map
-status: planning
+status: living
 audience: implementation agents (Claude, Codex), reviewers
-last_updated: 2026-05-07
+last_updated: 2026-05-10
 ---
 
 # Component Map
+
+> **Status as of 2026-05-10**: every public route in this map has
+> shipped (homepage, projects + slug, games + slug, gallery + slug,
+> blog timeline, media, resources, about, contact, portal, 404). The
+> `/tools` route was cut in Phase 4.5 — it duplicated `/resources`
+> and was orphaned. Section-by-section composition below is still
+> useful as a reference; flag drift in a follow-up if a page strays.
 
 Page-by-page composition for the redesign. Each section answers:
 

--- a/docs/GALLERY_SOCIAL_SPEC.md
+++ b/docs/GALLERY_SOCIAL_SPEC.md
@@ -1,11 +1,19 @@
 ---
 title: M4rkyu.com — Gallery Social Spec
-status: planning
+status: living
 audience: implementation agents (Claude, Codex), reviewers
-last_updated: 2026-05-07
+last_updated: 2026-05-10
 ---
 
 # Gallery Social Spec
+
+> **Status as of 2026-05-10**: visitor-local social MVP shipped
+> (Phase 1) — likes, saves, share via `src/lib/social/*`. Backed by
+> `localStorage` with a `useSyncExternalStore` channel; the lib
+> boundary is swap-ready for KV (Sprint 6.A) when the user provides
+> Upstash / Vercel KV secrets. Saved frames page lives at
+> `/<locale>/gallery/saved` and is `noindex` per Phase 5.1. UI:
+> Like / Save / Share affordances ship on every gallery frame.
 
 The gallery is the most public-facing surface on the site — the page most
 likely to get DM'd, reposted, and bookmarked. This document defines its

--- a/docs/REDESIGN_DIRECTION.md
+++ b/docs/REDESIGN_DIRECTION.md
@@ -1,13 +1,21 @@
 ---
 title: M4rkyu.com — Redesign Direction
-status: planning
+status: living
 audience: design + engineering agents (Claude, Codex, human collaborators)
-last_updated: 2026-05-07
+last_updated: 2026-05-10
 ---
 
 # Redesign Direction
 
-This is the creative brief for the next iteration of **m4rkyu.com**. It is
+> **Status as of 2026-05-10**: Sprints 1–5 shipped (24 PRs to
+> `main`, #12–#35; see `git log --oneline`). Brand vocabulary, atmospheric
+> stack, two-theme system, Cmd-K palette, sitemap + per-route OG,
+> and PR CI are all live. This file remains the design north star —
+> if a section conflicts with what shipped, the implementation wins
+> and this file should be edited in a follow-up. See
+> `AI_WORKFLOW.md` for cadence + conventions.
+
+This is the creative brief for the **2027 m4rkyu.com**. It is
 opinionated on purpose. Future agents should treat the calls in this file as
 the first draft of design intent — not a menu of options to second-guess.
 

--- a/docs/UI_LIBRARY_STRATEGY.md
+++ b/docs/UI_LIBRARY_STRATEGY.md
@@ -1,11 +1,19 @@
 ---
 title: M4rkyu.com — UI Library Strategy
-status: planning
+status: living
 audience: implementation agents (Claude, Codex), reviewers
-last_updated: 2026-05-07
+last_updated: 2026-05-10
 ---
 
 # UI Library Strategy
+
+> **Status as of 2026-05-10**: shipped Magic UI primitives (copy-in,
+> tokenized): `BlurFade`, `AnimatedGridPattern`, `BentoGrid`,
+> `BorderBeam`, `PointerSpotlight`, `ShineBorder`, `Particles`. All
+> live under `src/components/ui/magic/`. Aceternity → folded into
+> `PointerSpotlight` (Phase 4.1). One Magic-UI primitive per
+> viewport rule held — verify before adding more. Storybook covers
+> every shipped primitive.
 
 This document defines **which UI sources** the redesign is allowed to draw
 from, **what each one is for**, and **how to keep the site from looking like


### PR DESCRIPTION
Polish + docs pass. Closes Sprint 5.

## Summary

- **New `docs/AI_WORKFLOW.md`** — vibe-coding playbook for the one-PR-per-phase cadence: cross-cutting rules from the Sprint 1 patterns memory, validation gate, code-reviewer subagent BLOCK/SHOULD-FIX/NIT contract, plan files + memory, background-task pattern for CI watching, subagent fan-out, when to ask clarifying questions, what auto-mode owns vs doesn't.
- **Existing four design docs** (REDESIGN_DIRECTION, UI_LIBRARY_STRATEGY, COMPONENT_MAP, GALLERY_SOCIAL_SPEC): bump frontmatter \`status: planning → living\`, \`last_updated: 2026-05-10\`, prepend a \"Status as of 2026-05-10\" preamble naming what shipped from each spec (24 PRs #12–#35, 7 Magic UI primitives, /tools route cut, social MVP with KV-swap-ready boundary).
- **README.md**:
  - Surfaces \`docs/AI_WORKFLOW.md\` at the top for new contributors (human or AI).
  - Documents the \`npm run validate\` aggregate script.
  - New **CI** section covering \`pr.yml\` + \`release.yml\` + Vercel/Snyk/Socket.
  - New **SEO** section listing sitemap.ts, robots.ts, lib/seo/{site,alternates,og-image}.
- **Cleanup**: deleted the orphaned \`.env.example\` (Firebase keys with no Firebase usage anywhere in src/). It was untracked, so no diff entry — just gone from working tree.

## Test plan

- [x] \`npm run validate\` silent
- [ ] PR CI green (lint+typecheck + Playwright smoke)
- [ ] Vercel preview renders unchanged (docs-only diff)
- [ ] Spot-check that \`docs/AI_WORKFLOW.md\` link in README.md resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)