### PR TITLE
feat: phase-7.1 theme toggle — view-transition cursor circle reveal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,33 @@
  * (icons, color tweaks) just work. */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
+/* Theme view-transition: when ThemeSwitcher sets data-theme-sweep="on"
+ * on <html> and the View Transitions API is available, the next
+ * theme is revealed via a circle expanding from the click position
+ * (--vt-cx / --vt-cy CSS vars set in the same JS click handler).
+ * Without `data-theme-sweep`, the default browser cross-fade plays
+ * for non-theme transitions (e.g. router moves) — we don't want
+ * route changes to circle-reveal too. */
+@media (prefers-reduced-motion: no-preference) {
+  /* Kill the default cross-fade on the OLD layer so the NEW layer
+   * reveals over a static snapshot — the circle keyframe owns the
+   * whole transition. */
+  [data-theme-sweep="on"]::view-transition-old(root) {
+    animation: none;
+  }
+  [data-theme-sweep="on"]::view-transition-new(root) {
+    animation: theme-sweep 520ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  }
+  @keyframes theme-sweep {
+    from {
+      clip-path: circle(0 at var(--vt-cx, 50%) var(--vt-cy, 50%));
+    }
+    to {
+      clip-path: circle(150% at var(--vt-cx, 50%) var(--vt-cy, 50%));
+    }
+  }
+}
+
 :root {
   color-scheme: light;
   --background: #f5f3ee;

--- a/src/components/theme/theme-switcher.tsx
+++ b/src/components/theme/theme-switcher.tsx
@@ -2,6 +2,7 @@
 
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
+import type { MouseEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -17,16 +18,59 @@ import {
  * `data-theme` attribute which the CSS selectors respond to.
  *
  * Clicking always lands the visitor on the *opposite* of the
- * currently-active resolved theme.
+ * currently-active resolved theme. When the View Transitions API
+ * is supported and the visitor hasn't asked for reduced motion,
+ * the swap animates as a circle reveal expanding from the click
+ * coordinates (or the button center for keyboard activation). All
+ * other paths fall through to a plain instant flip.
  */
 export function ThemeSwitcher() {
   const { resolvedTheme, setTheme } = useTheme();
 
-  function toggle() {
+  function toggle(event: MouseEvent<HTMLButtonElement>) {
     // Read at click time so we always flip from the current resolved
     // value, not from a stale render.
     const next = resolvedTheme === "dark" ? "light" : "dark";
-    setTheme(next);
+
+    if (typeof document === "undefined") {
+      setTheme(next);
+      return;
+    }
+
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    if (typeof document.startViewTransition !== "function" || reduceMotion) {
+      setTheme(next);
+      return;
+    }
+
+    // Anchor the reveal at the cursor. `event.detail === 0` is the
+    // canonical "click was synthesized by keyboard activation"
+    // signal — fall back to the button center then so Enter/Space
+    // doesn't reveal from the viewport origin.
+    const rect = event.currentTarget.getBoundingClientRect();
+    const fromKeyboard = event.detail === 0;
+    const cx = fromKeyboard ? rect.left + rect.width / 2 : event.clientX;
+    const cy = fromKeyboard ? rect.top + rect.height / 2 : event.clientY;
+    const root = document.documentElement;
+    root.style.setProperty("--vt-cx", `${cx}px`);
+    root.style.setProperty("--vt-cy", `${cy}px`);
+    root.dataset.themeSweep = "on";
+
+    const transition = document.startViewTransition(() => {
+      setTheme(next);
+    });
+    // `transition.finished` rejects when the transition is skipped
+    // (e.g. a second click aborts the first). Catch so the reject
+    // doesn't surface as an unhandledrejection; finally always
+    // clears the data attribute.
+    void transition.finished
+      .catch(() => undefined)
+      .finally(() => {
+        delete root.dataset.themeSweep;
+      });
   }
 
   return (


### PR DESCRIPTION
Sprint 7 launch. Pure visual flourish — the canonical payoff for the Phase 4.5 single-icon theme switcher. No semantic change.

## What ships

- \`ThemeSwitcher\` onClick now wraps \`setTheme(next)\` in \`document.startViewTransition\` when the API exists and reduced-motion is **off**.
- Anchors the reveal at \`event.clientX/Y\`; falls back to the button center for keyboard activation (\`event.detail === 0\`).
- Writes \`--vt-cx\` / \`--vt-cy\` CSS vars and \`data-theme-sweep=\"on\"\` to \`<html>\` before kicking off the transition; clears \`data-theme-sweep\` in \`.finished.catch().finally()\` so a double-click rejection doesn't surface as unhandledrejection.
- \`typeof document\` guard before reading \`startViewTransition\`.
- \`globals.css\` adds an \`@media (prefers-reduced-motion: no-preference)\` block scoped to \`[data-theme-sweep=\"on\"]\` only, so route-change view transitions don't reuse this keyframe:
  - \`::view-transition-old(root) { animation: none }\` kills the default cross-fade.
  - \`::view-transition-new(root) { animation: theme-sweep 520ms ... }\` runs a \`clip-path: circle(0 → 150% at var(--vt-cx) var(--vt-cy))\` expansion.

## Fallback paths

- View Transitions API unsupported (Safari < 18, Firefox without the flag) → plain instant flip.
- \`prefers-reduced-motion: reduce\` → plain instant flip (gated in JS **and** by the CSS \`@media\`).
- SSR / no document → plain flip.

## Test plan

- [x] \`npm run validate\` silent
- [ ] PR CI green (lint + typecheck + Playwright smoke; theme-toggle test from Phase 4.5 still asserts data-theme flips)
- [ ] Manual on Chromium 111+: click toggle anywhere on the page → circle reveals from cursor position; double-click → no console error.
- [ ] Manual keyboard: Tab to toggle, Enter → reveal anchors from button center.
- [ ] Manual on Firefox/Safari with View Transitions disabled → instant flip, no jank.
- [ ] DevTools \`prefers-reduced-motion: reduce\` → instant flip, no animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)