### PR TITLE
feat: phase-7.2 single-shot RGB-split glitch on archive H1s

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,52 @@
  * for non-theme transitions (e.g. router moves) — we don't want
  * route changes to circle-reveal too. */
 @media (prefers-reduced-motion: no-preference) {
+  /* GlitchText (Phase 7.2) — single-shot RGB-split glitch on mount.
+   * Pseudo-elements duplicate the text via `data-text`, sliced into
+   * top/bottom halves and offset in the ring + signal colors. The
+   * `both` keyword keeps the pseudo layers at their final
+   * (transparent) state after the keyframe finishes, so the title
+   * sits still after entry. */
+  .glitch-text::before,
+  .glitch-text::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    /* Inherit typography explicitly so a future change to the host
+     * heading class can't silently leave the duplicates behind. */
+    font: inherit;
+    line-height: inherit;
+    pointer-events: none;
+    user-select: none;
+  }
+  .glitch-text::before {
+    color: var(--ring);
+    animation: glitch-slice-a 320ms steps(6, end) 1 both;
+  }
+  /* `--signal` is defined on `:root` (light) and intentionally not
+   * overridden in dark — the saturated red reads cleanly on both
+   * surfaces and matches the live-signal dot in StatusPulseRow. */
+  .glitch-text::after {
+    color: var(--signal);
+    animation: glitch-slice-b 320ms steps(6, end) 1 both;
+  }
+  @keyframes glitch-slice-a {
+    0% { clip-path: inset(0 0 65% 0); transform: translate(-3px, 0); opacity: 0.85; }
+    25% { clip-path: inset(15% 0 60% 0); transform: translate(2px, 0); opacity: 0.7; }
+    50% { clip-path: inset(8% 0 70% 0); transform: translate(-2px, 0); opacity: 0.6; }
+    75% { clip-path: inset(20% 0 50% 0); transform: translate(1px, 0); opacity: 0.4; }
+    100% { clip-path: inset(0 0 65% 0); transform: translate(0, 0); opacity: 0; }
+  }
+  @keyframes glitch-slice-b {
+    0% { clip-path: inset(60% 0 0 0); transform: translate(3px, 0); opacity: 0.85; }
+    25% { clip-path: inset(50% 0 10% 0); transform: translate(-2px, 0); opacity: 0.7; }
+    50% { clip-path: inset(70% 0 5% 0); transform: translate(2px, 0); opacity: 0.6; }
+    75% { clip-path: inset(40% 0 25% 0); transform: translate(-1px, 0); opacity: 0.4; }
+    100% { clip-path: inset(60% 0 0 0); transform: translate(0, 0); opacity: 0; }
+  }
+
   /* Kill the default cross-fade on the OLD layer so the NEW layer
    * reveals over a static snapshot — the circle keyframe owns the
    * whole transition. */

--- a/src/components/motion/glitch-text.stories.tsx
+++ b/src/components/motion/glitch-text.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { GlitchText } from "./glitch-text";
+
+const meta = {
+  title: "Motion/GlitchText",
+  component: GlitchText,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof GlitchText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: "Project Archive",
+    className:
+      "text-4xl font-[700] leading-[1.05] tracking-normal sm:text-5xl",
+  },
+};
+
+export const LongerTitle: Story = {
+  args: {
+    children: "Software · Games · Digital Art",
+    className: "text-3xl font-[700] leading-[1.05] tracking-normal",
+  },
+};
+
+export const ShortToken: Story = {
+  args: {
+    children: "PORTAL",
+    className:
+      "font-[family-name:var(--font-display)] text-6xl font-[800] tracking-tight",
+  },
+};
+
+// Set the OS to `prefers-reduced-motion: reduce` to see the
+// short-circuit branch — the host renders as plain text with no
+// pseudo-element decoration. There is no Storybook addon required;
+// the JS short-circuit + the CSS @media wrapper both honor the
+// system setting.
+export const ReducedMotion: Story = {
+  args: {
+    children: "Reduced-motion fallback",
+    className: "text-3xl font-[700]",
+  },
+};

--- a/src/components/motion/glitch-text.tsx
+++ b/src/components/motion/glitch-text.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface GlitchTextProps {
+  children: string;
+  className?: string;
+}
+
+/**
+ * Single-shot RGB-split glitch on mount. Renders three layers:
+ * - the visible text (foreground colour);
+ * - `::before` clipped to the upper half, pushed -2px in the ring colour;
+ * - `::after` clipped to the lower half, pushed +2px in the signal colour.
+ *
+ * The keyframes (`glitch-slice-a`, `glitch-slice-b`) live in
+ * `globals.css`. They're step-based and run once for ~320ms, then
+ * the pseudo-element layers settle to opacity:0 so the title sits
+ * still after the entry. Reduced-motion → plain text, no pseudo
+ * decoration.
+ *
+ * The `data-text` attribute is what the pseudo-elements duplicate;
+ * `children` must be a plain string.
+ */
+export function GlitchText({ children, className }: GlitchTextProps) {
+  const reduceMotion = useReducedMotion();
+  if (reduceMotion) {
+    return <span className={className}>{children}</span>;
+  }
+  return (
+    // The visible text is the host's own children, so screen
+    // readers announce it directly. Pseudo-element `content` is
+    // excluded from the a11y tree, so no `aria-label` needed —
+    // adding one would risk double-announcement on some AT.
+    <span
+      className={cn("glitch-text relative inline-block", className)}
+      data-text={children}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/sections/section-heading.tsx
+++ b/src/components/sections/section-heading.tsx
@@ -1,3 +1,5 @@
+import { GlitchText } from "@/components/motion/glitch-text";
+
 interface SectionHeadingProps {
   eyebrow?: string;
   title: string;
@@ -9,6 +11,13 @@ interface SectionHeadingProps {
    * `h1` via `CaseStudyHeader` / `GameDetailHeader`.
    */
   as?: "h1" | "h2";
+  /**
+   * Opt out of the single-shot glitch effect on the H1. Defaults to
+   * false so archive page titles get the entry animation; pages
+   * that want a quieter reveal (or already animate the title via
+   * another path) can disable it.
+   */
+  disableGlitch?: boolean;
 }
 
 const headingClass =
@@ -19,8 +28,10 @@ export function SectionHeading({
   title,
   description,
   as = "h2",
+  disableGlitch = false,
 }: SectionHeadingProps) {
   const Heading = as;
+  const useGlitch = as === "h1" && !disableGlitch;
   return (
     <div className="max-w-3xl">
       {eyebrow ? (
@@ -28,7 +39,9 @@ export function SectionHeading({
           {eyebrow}
         </p>
       ) : null}
-      <Heading className={headingClass}>{title}</Heading>
+      <Heading className={headingClass}>
+        {useGlitch ? <GlitchText>{title}</GlitchText> : title}
+      </Heading>
       {description ? (
         <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
           {description}


### PR DESCRIPTION
Sprint 7 phase 2. Pure visual flourish on archive page titles — no semantic change, no SEO impact (the H1 still contains the title as plain text content).

## What ships

- **`src/components/motion/glitch-text.tsx`** — client component. Takes a string child, sets it as \`data-text\` on a span, lets CSS pseudo-elements duplicate it. \`useReducedMotion()\` short-circuits to plain text.
- **\`globals.css\`** adds keyframes inside the existing \`@media (prefers-reduced-motion: no-preference)\` block:
  - \`::before\` runs \`glitch-slice-a\` 320ms steps(6) once with \`both\` (lands at opacity:0).
  - \`::after\` runs \`glitch-slice-b\` 320ms steps(6) once with \`both\`.
  - \`::before\` color = \`var(--ring)\` (cyan), \`::after\` color = \`var(--signal)\` (red — matches the pulse-row live dot).
  - Pseudos inherit \`font\` + \`line-height\` so future heading class changes can't desync the duplicates.
- **\`SectionHeading\`** gains a \`disableGlitch?: boolean\` prop (default false). When \`as === \"h1\" && !disableGlitch\`, wraps the title in \`<GlitchText>\`. h2 paths and the detail-page \`CaseStudyHeader\` / \`GameDetailHeader\` are untouched.
- New \`glitch-text.stories.tsx\` — Default, LongerTitle, ShortToken, ReducedMotion.

## Reduced-motion + a11y

- JS short-circuit + CSS \`@media\` wrapper — both honor the setting.
- No \`aria-label\` on the host span: pseudo-element \`content\` is excluded from the a11y tree, so the visible text is the only thing screen readers announce.
- After the 320ms entry, both pseudo layers sit at \`opacity: 0\` — the title is pixel-stable for screenshot tests.

## Test plan

- [x] \`npm run validate\` silent
- [ ] PR CI green (lint + typecheck + Playwright smoke)
- [ ] Manual: navigate to \`/en/projects\`, \`/en/games\`, \`/en/blog\`, \`/en/gallery\`, \`/en/resources\` — each archive H1 plays a 320ms RGB-split glitch on first paint.
- [ ] Manual: case-study detail page (\`/en/projects/nimbus\`) — header (CaseStudyHeader) is untouched.
- [ ] DevTools \`prefers-reduced-motion: reduce\` — titles render plain, no glitch.
- [ ] Visit \`/en/about\` — uses a custom \`<h1>\`, not SectionHeading; should remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)