### PR TITLE
feat: phase-7.3 localized metadata for contact / gallery / resources / media

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -188,6 +188,16 @@
     "title": "About Mark",
     "intro": "A China to Canada software and art path shaped by Western University, J.D. Power, game development, and a sustained interest in systems that feel human."
   },
+  "Meta": {
+    "galleryTitle": "Gallery",
+    "galleryDescription": "Black-and-white photography, digital art, and contact sheets — visual archive by ZhenXiao Mark Yu.",
+    "resourcesTitle": "Resources",
+    "resourcesDescription": "Tools, frameworks, and references — the small personal stack actually in use.",
+    "contactTitle": "Contact",
+    "contactDescription": "Project inquiries and collaboration. Mailto and form fallback now, server-side provider later.",
+    "mediaTitle": "Media",
+    "mediaDescription": "Video and process archive — draft frames hold the layout while final clips and posters land."
+  },
   "Portal": {
     "title": "Portal",
     "intro": "An opt-in interactive route. For now, the terminal stays light, fast, and quiet — atmosphere only.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -188,6 +188,16 @@
     "title": "关于 Mark",
     "intro": "从中国到加拿大，从 Western University 到 J.D. Power，再到软件、游戏与艺术的交叉实践。Mark 关注的是有温度的系统。"
   },
+  "Meta": {
+    "galleryTitle": "影像",
+    "galleryDescription": "黑白摄影、数字艺术与样片 —— 于震潇的视觉档案。",
+    "resourcesTitle": "资源",
+    "resourcesDescription": "工具、框架与参考 —— 真正在使用的小型个人技术栈。",
+    "contactTitle": "联系",
+    "contactDescription": "项目咨询与合作。当前提供邮件与表单回退，后续接入服务端表单服务。",
+    "mediaTitle": "媒体",
+    "mediaDescription": "视频与流程档案 —— 占位帧先撑住版面，正式片段与海报随后替换。"
+  },
   "Portal": {
     "title": "Portal",
     "intro": "可选的交互式路由。当前保持轻量、快速、安静 —— 仅有氛围层。",

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,10 +17,10 @@ export async function generateMetadata({
   params: Promise<{ locale: Locale }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  const tMeta = await getTranslations({ locale, namespace: "Meta" });
   return {
-    title: "Contact",
-    description:
-      "Project inquiries and collaboration. Mailto and form fallback now, server-side provider later.",
+    title: tMeta("contactTitle"),
+    description: tMeta("contactDescription"),
     alternates: buildAlternates(locale, "/contact"),
   };
 }

--- a/src/app/[locale]/gallery/page.tsx
+++ b/src/app/[locale]/gallery/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
 import { ArchiveCard } from "@/components/cards/archive-card"
 import { PageShell } from "@/components/layout/page-shell"
 import { SectionHeading } from "@/components/sections/section-heading"
@@ -16,10 +17,10 @@ export async function generateMetadata({
   params: Promise<{ locale: Locale }>
 }): Promise<Metadata> {
   const { locale } = await params
+  const tMeta = await getTranslations({ locale, namespace: "Meta" })
   return {
-    title: "Gallery",
-    description:
-      "Black-and-white photography, digital art, and contact sheets — visual archive by ZhenXiao Mark Yu.",
+    title: tMeta("galleryTitle"),
+    description: tMeta("galleryDescription"),
     alternates: buildAlternates(locale, "/gallery"),
   }
 }

--- a/src/app/[locale]/media/page.tsx
+++ b/src/app/[locale]/media/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PlaceholderVideo } from "@/components/placeholders/placeholder-video";
 import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
 import { MediaFrame } from "@/components/placeholders/media-frame";
+import { getTranslations } from "next-intl/server";
 import { mediaItems } from "@/content/media";
 import type { Locale } from "@/i18n/routing";
 import { buildAlternates } from "@/lib/seo/alternates";
@@ -16,9 +17,10 @@ export async function generateMetadata({
   params: Promise<{ locale: Locale }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  const tMeta = await getTranslations({ locale, namespace: "Meta" });
   return {
-    title: "Media",
-    description: "Video and process archive — draft frames hold the layout while final clips and posters land.",
+    title: tMeta("mediaTitle"),
+    description: tMeta("mediaDescription"),
     alternates: buildAlternates(locale, "/media"),
   };
 }

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { EmptyArchiveState } from "@/components/placeholders/empty-archive-state";
@@ -13,10 +14,10 @@ export async function generateMetadata({
   params: Promise<{ locale: Locale }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  const tMeta = await getTranslations({ locale, namespace: "Meta" });
   return {
-    title: "Resources",
-    description:
-      "Tools, frameworks, and references — the small personal stack actually in use.",
+    title: tMeta("resourcesTitle"),
+    description: tMeta("resourcesDescription"),
     alternates: buildAlternates(locale, "/resources"),
   };
 }


### PR DESCRIPTION
Closes the SEO i18n gap flagged in Phase 5.1's code review: four routes were emitting English \`<title>\` and \`<meta description>\` tags on \`/zh\` paths because their \`generateMetadata\` called English string literals.

## What ships

- **New shared \`Meta\` namespace** in \`messages/{en,zh}.json\`. Eight keys: \`galleryTitle\`/\`galleryDescription\`, \`resourcesTitle\`/\`resourcesDescription\`, \`contactTitle\`/\`contactDescription\`, \`mediaTitle\`/\`mediaDescription\`. CJK hand-translated.
- \`contact/page.tsx\`, \`gallery/page.tsx\`, \`resources/page.tsx\`, \`media/page.tsx\` — \`generateMetadata\` now reads from \`getTranslations(\"Meta\")\` instead of hardcoded literals.
- \`about\` and \`portal\` already used localized metadata (Phase 5.1) via their own About / Portal namespaces — unchanged.

## Out of scope

- OG images stay Latin-only — \`next/og\`'s default font has no CJK glyph coverage. Bundling a Noto Sans SC subset is parked until the social-preview value justifies the font budget.

## Test plan

- [x] \`npm run validate\` silent
- [ ] PR CI green
- [ ] View source on \`/zh/contact\` → \`<title>联系\` and CJK description
- [ ] View source on \`/zh/gallery\`, \`/zh/resources\`, \`/zh/media\` — same
- [ ] \`/en/*\` for the same routes still serves English copy unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)