### PR TITLE
feat: phase-8.2 in-site /blog/[slug] with markdown pipeline

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,15 @@ const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   images: {
     formats: ["image/avif", "image/webp"],
+    // Dev.to-syndicated post bodies (Phase 8.2) reference images
+    // hosted on Forem's CDN and the underlying S3 bucket. Any new
+    // upstream image host added here must be a known, trusted CDN.
+    remotePatterns: [
+      { protocol: "https", hostname: "media.dev.to" },
+      { protocol: "https", hostname: "media2.dev.to" },
+      { protocol: "https", hostname: "media3.dev.to" },
+      { protocol: "https", hostname: "dev-to-uploads.s3.amazonaws.com" },
+    ],
   },
   experimental: {
     cpus: 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "next-themes": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-markdown": "^9.1.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.4.2"
       },
@@ -7691,6 +7693,16 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/icu-minify": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.11.0.tgz",
@@ -8881,6 +8893,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8889,6 +8911,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -8909,6 +8959,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9138,6 +9289,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -10643,6 +10915,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -10892,6 +11191,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
@@ -10933,6 +11250,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^9.1.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.4.2"
   },

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
+import { PageShell } from "@/components/layout/page-shell";
+import { PostHeader } from "@/components/blog/post-header";
+import { PostBody } from "@/components/blog/post-body";
+import { CaseStudyFooter } from "@/components/case-study/case-study-footer";
+import type { Locale } from "@/i18n/routing";
+import { buildAlternates } from "@/lib/seo/alternates";
+import { getPostBySlug, getAllPostSlugs } from "@/lib/blog/get-post";
+import {
+  fetchDevtoArticles,
+  type DevtoArticleListItem,
+} from "@/lib/blog/devto";
+import { DEVTO_USERNAME } from "@/lib/blog/get-posts";
+
+export async function generateStaticParams() {
+  const slugs = await getAllPostSlugs();
+  return slugs.flatMap((slug) => [
+    { locale: "en", slug },
+    { locale: "zh", slug },
+  ]);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale; slug: string }>;
+}): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const resolved = await getPostBySlug(slug);
+  if (!resolved) return {};
+  const { meta } = resolved;
+  return {
+    title: meta.title,
+    description: meta.description,
+    // Per Phase 5.1's hreflang strategy, route alternates point at
+    // our locale-prefixed paths. The `canonical` here intentionally
+    // **overrides** the in-site URL with the dev.to canonical so
+    // search engines treat dev.to as the source of truth.
+    alternates: {
+      ...buildAlternates(locale, `/blog/${slug}`),
+      canonical: meta.canonical_url,
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: meta.canonical_url,
+      type: "article",
+      images: meta.cover_image ? [meta.cover_image] : undefined,
+    },
+  };
+}
+
+function adjacentEntry(article: DevtoArticleListItem | undefined) {
+  if (!article) return undefined;
+  return {
+    href: `/blog/${article.slug}`,
+    title: article.title,
+    pitch: article.description,
+  };
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ locale: Locale; slug: string }>;
+}) {
+  const { locale, slug } = await params;
+  const resolved = await getPostBySlug(slug);
+  if (!resolved) notFound();
+
+  // Hit the listing once more to resolve adjacent metadata for the
+  // footer prev/next cards. Shares Next's data cache with
+  // `getPostBySlug` — no extra upstream call.
+  // dev.to lists newest-first, so `articles[idx + 1]` is the OLDER
+  // (previous in archive reading order) post; `articles[idx - 1]`
+  // is the NEWER (next chronologically).
+  const articles = await fetchDevtoArticles(DEVTO_USERNAME);
+  const idx = articles.findIndex((a) => a.slug === slug);
+  const prev = adjacentEntry(
+    idx >= 0 && idx < articles.length - 1 ? articles[idx + 1] : undefined,
+  );
+  const next = adjacentEntry(idx > 0 ? articles[idx - 1] : undefined);
+
+  const { meta, full } = resolved;
+
+  return (
+    <PageShell locale={locale}>
+      <article>
+        <PostHeader
+          title={meta.title}
+          description={meta.description}
+          date={meta.readable_publish_date}
+          readingTime={`${meta.reading_time_minutes} min read`}
+          tags={meta.tag_list}
+          canonicalUrl={meta.canonical_url}
+          reactionsCount={meta.positive_reactions_count}
+          commentsCount={meta.comments_count}
+          cover={
+            meta.cover_image
+              ? { src: meta.cover_image, alt: meta.title }
+              : undefined
+          }
+          username={DEVTO_USERNAME}
+        />
+
+        <section className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
+          <PostBody markdown={full.body_markdown} />
+        </section>
+
+        <section className="mx-auto w-full max-w-3xl border-t px-4 py-10 sm:px-6 lg:px-8">
+          <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
+            originally published
+          </p>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-muted-foreground">
+              This post first ran on dev.to. Comments and reactions live there.
+            </p>
+            <a
+              href={meta.canonical_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
+            >
+              <span>Continue on dev.to</span>
+              <ArrowUpRight aria-hidden="true" className="size-3.5" />
+            </a>
+          </div>
+        </section>
+
+        <CaseStudyFooter prev={prev} next={next} archiveHref="/blog" />
+      </article>
+    </PageShell>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -73,10 +73,7 @@ export default async function HomePage({
       kind: "writing",
       label: writing.title,
       detail: writing.excerpt,
-      // Prefer the dev.to canonical URL when set so the homepage
-      // never links into an unbuilt route. Phase 8.2 will add the
-      // in-site /blog/[slug] and this can flip back to a local path.
-      href: writing.canonicalUrl ?? `/blog/${writing.slug}`,
+      href: `/blog/${writing.slug}`,
     });
   }
   const now = games.find((g) => g.status !== "ready") ?? games[0];

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,7 @@ import { games } from "@/content/games";
 import { galleryCollections } from "@/content/gallery";
 import { routing, type Locale } from "@/i18n/routing";
 import { SITE_URL } from "@/lib/seo/site";
+import { getAllPostSlugs } from "@/lib/blog/get-post";
 
 // Stable timestamp computed at build time. Real `lastModified` per
 // entry will land when content data carries explicit dates;
@@ -47,7 +48,7 @@ function entry(
   );
 }
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticEntries = STATIC_PATHS.flatMap(({ path, changeFrequency, priority }) =>
     entry(path, changeFrequency, priority),
   );
@@ -68,10 +69,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
       entry(`/gallery/${collection.slug}`, "monthly", 0.6),
     );
 
+  // Phase 8.2 — dev.to-syndicated post slugs land in the sitemap
+  // so the in-site /blog/[slug] route is discoverable. The page
+  // itself sets `alternates.canonical` to the dev.to URL so search
+  // engines treat dev.to as the source of truth.
+  const blogSlugs = await getAllPostSlugs();
+  const blogEntries = blogSlugs.flatMap((slug) =>
+    entry(`/blog/${slug}`, "weekly", 0.6),
+  );
+
   return [
     ...staticEntries,
     ...projectEntries,
     ...gameEntries,
     ...galleryEntries,
+    ...blogEntries,
   ];
 }

--- a/src/components/blog/post-body.tsx
+++ b/src/components/blog/post-body.tsx
@@ -1,0 +1,221 @@
+import Image from "next/image";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Components } from "react-markdown";
+import { cn } from "@/lib/utils";
+
+interface PostBodyProps {
+  markdown: string;
+  className?: string;
+}
+
+/**
+ * Renders dev.to-syndicated post bodies with the site's editorial
+ * prose vocabulary instead of dev.to's defaults.
+ *
+ * - All elements are owned via the `components` map so headings,
+ *   blockquotes, code, lists, and tables match the rest of the
+ *   case-study surfaces (border-y rules, mono code, ring accents).
+ * - Images route through `next/image` with explicit
+ *   width/height + lazy loading. dev.to hosts on its CDN so the
+ *   `unoptimized` flag stays off — Next.js will optimize them.
+ * - Code fences pass through with the language hint left on the
+ *   `<pre>`/`<code>` for a future syntax-highlighting pass; the
+ *   `font-mono` styles read well unhighlighted.
+ */
+const components: Components = {
+  h1: ({ className, ...props }) => (
+    <h1
+      {...props}
+      className={cn(
+        "mt-12 scroll-mt-24 font-[family-name:var(--font-display)] text-3xl font-semibold tracking-tight text-foreground sm:text-4xl",
+        className,
+      )}
+    />
+  ),
+  h2: ({ className, ...props }) => (
+    <h2
+      {...props}
+      className={cn(
+        "mt-10 scroll-mt-24 font-[family-name:var(--font-display)] text-2xl font-semibold tracking-tight text-foreground sm:text-3xl",
+        className,
+      )}
+    />
+  ),
+  h3: ({ className, ...props }) => (
+    <h3
+      {...props}
+      className={cn(
+        "mt-8 scroll-mt-24 text-xl font-semibold leading-snug text-foreground",
+        className,
+      )}
+    />
+  ),
+  h4: ({ className, ...props }) => (
+    <h4
+      {...props}
+      className={cn(
+        "mt-6 scroll-mt-24 text-lg font-semibold leading-snug text-foreground",
+        className,
+      )}
+    />
+  ),
+  p: ({ className, ...props }) => (
+    <p
+      {...props}
+      className={cn("mt-5 text-base leading-7 text-foreground/90", className)}
+    />
+  ),
+  a: ({ className, href, children, ...props }) => {
+    const external = typeof href === "string" && /^https?:\/\//i.test(href);
+    return (
+      <a
+        {...props}
+        href={href}
+        target={external ? "_blank" : undefined}
+        rel={external ? "noopener noreferrer" : undefined}
+        className={cn(
+          "text-foreground underline decoration-ring/60 underline-offset-4 transition-colors hover:decoration-ring",
+          className,
+        )}
+      >
+        {children}
+      </a>
+    );
+  },
+  ul: ({ className, ...props }) => (
+    <ul
+      {...props}
+      className={cn(
+        "mt-5 ml-6 list-disc space-y-2 text-base leading-7 text-foreground/90 marker:text-muted-foreground",
+        className,
+      )}
+    />
+  ),
+  ol: ({ className, ...props }) => (
+    <ol
+      {...props}
+      className={cn(
+        "mt-5 ml-6 list-decimal space-y-2 text-base leading-7 text-foreground/90 marker:font-mono marker:text-xs marker:text-muted-foreground",
+        className,
+      )}
+    />
+  ),
+  li: ({ className, ...props }) => (
+    <li {...props} className={cn("pl-1", className)} />
+  ),
+  blockquote: ({ className, ...props }) => (
+    <blockquote
+      {...props}
+      className={cn(
+        "mt-6 border-l-2 border-ring/60 pl-5 text-base italic leading-7 text-muted-foreground",
+        className,
+      )}
+    />
+  ),
+  hr: ({ className, ...props }) => (
+    <hr
+      {...props}
+      aria-hidden="true"
+      className={cn("my-10 border-border/70", className)}
+    />
+  ),
+  code: ({ className, children, ...props }) => {
+    // react-markdown renders fenced code as `<pre><code>…</code></pre>`
+    // and inline code as bare `<code>`. v9 doesn't expose a parent
+    // pointer in the component props, so detect "fenced" via two
+    // signals:
+    // 1. a `language-*` className (set when the fence has a hint)
+    // 2. a children string containing a newline (set on every fence
+    //    body, inline code never spans lines in practice)
+    const hasNewline =
+      typeof children === "string" && children.includes("\n");
+    const isFenced = className?.startsWith("language-") || hasNewline;
+    if (!isFenced) {
+      return (
+        <code
+          {...props}
+          className={cn(
+            "rounded-sm border border-border/80 bg-muted/60 px-1.5 py-0.5 font-mono text-[0.85em] text-foreground",
+            className,
+          )}
+        >
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code {...props} className={cn("font-mono text-sm", className)}>
+        {children}
+      </code>
+    );
+  },
+  pre: ({ className, ...props }) => (
+    <pre
+      {...props}
+      className={cn(
+        "mt-6 overflow-x-auto rounded-md border border-border bg-muted/50 p-4 font-mono text-sm leading-6",
+        className,
+      )}
+    />
+  ),
+  table: ({ className, ...props }) => (
+    <div className="mt-6 overflow-x-auto">
+      <table
+        {...props}
+        className={cn(
+          "w-full border-collapse text-left text-sm",
+          className,
+        )}
+      />
+    </div>
+  ),
+  th: ({ className, ...props }) => (
+    <th
+      {...props}
+      className={cn(
+        "border-b border-border px-3 py-2 font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground",
+        className,
+      )}
+    />
+  ),
+  td: ({ className, ...props }) => (
+    <td
+      {...props}
+      className={cn("border-b border-border/60 px-3 py-2", className)}
+    />
+  ),
+  img: ({ src, alt, className }) => {
+    if (typeof src !== "string") return null;
+    return (
+      <span className="mt-6 block">
+        <Image
+          src={src}
+          alt={alt ?? ""}
+          width={1280}
+          height={720}
+          sizes="(min-width: 1024px) 800px, 100vw"
+          className={cn(
+            "h-auto w-full rounded-md border border-border bg-muted",
+            className,
+          )}
+        />
+        {alt ? (
+          <span className="mt-2 block text-center font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground">
+            {alt}
+          </span>
+        ) : null}
+      </span>
+    );
+  },
+};
+
+export function PostBody({ markdown, className }: PostBodyProps) {
+  return (
+    <div className={cn("max-w-3xl", className)}>
+      <Markdown remarkPlugins={[remarkGfm]} components={components}>
+        {markdown}
+      </Markdown>
+    </div>
+  );
+}

--- a/src/components/blog/post-header.tsx
+++ b/src/components/blog/post-header.tsx
@@ -1,0 +1,157 @@
+import { ArrowUpRight, Heart, MessageSquare } from "lucide-react";
+import Image from "next/image";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface PostHeaderProps {
+  title: string;
+  description: string;
+  date: string;
+  readingTime: string;
+  tags: string[];
+  canonicalUrl: string;
+  reactionsCount: number;
+  commentsCount: number;
+  cover?: { src: string; alt: string };
+  username: string;
+}
+
+/**
+ * Editorial header for a syndicated dev.to post. Same atmospheric
+ * stack as case-study and game detail headers (cyber-grid + archive
+ * vignette), but the meta ribbon below the title surfaces dev.to-
+ * specific signals: reactions, comments, and a "view on dev.to" CTA
+ * that opens the canonical source in a new tab.
+ */
+export function PostHeader({
+  title,
+  description,
+  date,
+  readingTime,
+  tags,
+  canonicalUrl,
+  reactionsCount,
+  commentsCount,
+  cover,
+  username,
+}: PostHeaderProps) {
+  return (
+    <header className="relative overflow-hidden border-b">
+      <div
+        className="absolute inset-0 bg-cyber-grid opacity-30"
+        aria-hidden="true"
+      />
+      <div className="archive-vignette absolute inset-0" aria-hidden="true" />
+      <div className="relative mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
+          syndicated · dev.to / @{username}
+        </p>
+
+        <h1 className="mt-6 font-[family-name:var(--font-display)] text-3xl font-semibold leading-tight tracking-tight text-balance sm:text-4xl lg:text-5xl">
+          {title}
+        </h1>
+
+        <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+          {description}
+        </p>
+
+        <dl className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <dt className="sr-only">Published</dt>
+            <dd>{date}</dd>
+          </div>
+          <span aria-hidden="true" className="text-muted-foreground/40">
+            ·
+          </span>
+          <div className="flex items-center gap-2">
+            <dt className="sr-only">Reading time</dt>
+            <dd>{readingTime}</dd>
+          </div>
+          {reactionsCount > 0 ? (
+            <>
+              <span aria-hidden="true" className="text-muted-foreground/40">
+                ·
+              </span>
+              <div className="flex items-center gap-1.5">
+                <Heart aria-hidden="true" className="size-3 text-signal" />
+                <dt className="sr-only">Reactions</dt>
+                <dd>{reactionsCount}</dd>
+              </div>
+            </>
+          ) : null}
+          {commentsCount > 0 ? (
+            <>
+              <span aria-hidden="true" className="text-muted-foreground/40">
+                ·
+              </span>
+              <div className="flex items-center gap-1.5">
+                <MessageSquare
+                  aria-hidden="true"
+                  className="size-3 text-muted-foreground"
+                />
+                <dt className="sr-only">Comments</dt>
+                <dd>{commentsCount}</dd>
+              </div>
+            </>
+          ) : null}
+        </dl>
+
+        {tags.length > 0 ? (
+          <div className="mt-5 flex flex-wrap gap-1.5">
+            {tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant="outline"
+                className="text-[0.6rem] lowercase tracking-[0.1em]"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Button asChild variant="outline" size="sm">
+            <a
+              href={canonicalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View on dev.to
+              <ArrowUpRight aria-hidden="true" className="size-3.5" />
+            </a>
+          </Button>
+          {commentsCount > 0 ? (
+            <Button asChild variant="ghost" size="sm">
+              <a
+                href={`${canonicalUrl}#comments`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <MessageSquare
+                  aria-hidden="true"
+                  className="size-3.5"
+                />
+                Discuss
+              </a>
+            </Button>
+          ) : null}
+        </div>
+
+        {cover ? (
+          <figure className="mt-10 overflow-hidden rounded-md border border-border">
+            <Image
+              src={cover.src}
+              alt={cover.alt}
+              width={1000}
+              height={420}
+              priority
+              sizes="(min-width: 768px) 768px, 100vw"
+              className="h-auto w-full"
+            />
+          </figure>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/src/components/cards/pinned-post-card.tsx
+++ b/src/components/cards/pinned-post-card.tsx
@@ -65,19 +65,6 @@ export async function PinnedPostCard({ post }: PinnedPostCardProps) {
     </>
   );
 
-  if (post.canonicalUrl) {
-    return (
-      <a
-        href={post.canonicalUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cardClass}
-      >
-        {body}
-      </a>
-    );
-  }
-
   return (
     <Link href={`/blog/${post.slug}`} className={cardClass}>
       {body}

--- a/src/components/cards/post-list-item.tsx
+++ b/src/components/cards/post-list-item.tsx
@@ -15,10 +15,10 @@ const monoMeta =
   "font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground";
 
 /**
- * Wraps the row in either a next-intl Link (in-site /blog/[slug])
- * or a plain external `<a>` (canonicalUrl on dev.to). Phase 8.1
- * routes everything to canonicalUrl; Phase 8.2 will flip to the
- * in-site detail when /blog/[slug] lands.
+ * Always routes to the in-site `/blog/[slug]` detail page (Phase
+ * 8.2). Syndicated posts now render in-site with a "View on dev.to"
+ * affordance inside the post header, so we no longer link out from
+ * the timeline.
  */
 function RowLink({
   post,
@@ -29,18 +29,6 @@ function RowLink({
   className: string;
   children: ReactNode;
 }) {
-  if (post.canonicalUrl) {
-    return (
-      <a
-        href={post.canonicalUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={className}
-      >
-        {children}
-      </a>
-    );
-  }
   return (
     <Link href={`/blog/${post.slug}`} className={className}>
       {children}

--- a/src/components/sections/writing-pulse-row.tsx
+++ b/src/components/sections/writing-pulse-row.tsx
@@ -91,31 +91,16 @@ function PulseSlot({
           </div>
         ) : null}
         <div className="mt-auto pt-1">
-          {post.canonicalUrl ? (
-            <a
-              href={post.canonicalUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
-            >
-              {t("read")}
-              <ArrowUpRight
-                aria-hidden="true"
-                className="size-3.5 transition-transform duration-(--motion-fast) group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
-              />
-            </a>
-          ) : (
-            <Link
-              href={`/blog/${post.slug}`}
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
-            >
-              {t("read")}
-              <ArrowUpRight
-                aria-hidden="true"
-                className="size-3.5 transition-transform duration-(--motion-fast) group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
-              />
-            </Link>
-          )}
+          <Link
+            href={`/blog/${post.slug}`}
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            {t("read")}
+            <ArrowUpRight
+              aria-hidden="true"
+              className="size-3.5 transition-transform duration-(--motion-fast) group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+            />
+          </Link>
         </div>
       </CardContent>
     </Card>

--- a/src/lib/blog/get-post.ts
+++ b/src/lib/blog/get-post.ts
@@ -1,0 +1,49 @@
+import {
+  fetchDevtoArticle,
+  fetchDevtoArticles,
+  type DevtoArticle,
+  type DevtoArticleListItem,
+} from "./devto";
+import { DEVTO_USERNAME } from "./get-posts";
+
+export interface ResolvedPost {
+  /** Listing-level metadata (slug, title, tag_list, etc.). */
+  meta: DevtoArticleListItem;
+  /** Full article including `body_markdown` + `body_html`. */
+  full: DevtoArticle;
+}
+
+/**
+ * Resolve a single dev.to article by slug.
+ *
+ * dev.to's per-article endpoint is keyed by `id`, not `slug`, so
+ * we hit the listing first to map slug → id, then fetch the full
+ * article. Both calls go through Next 15 ISR (24h cache), so
+ * repeated post-page renders share data with the timeline.
+ *
+ * Returns `null` when the slug is unknown so the page can call
+ * `notFound()`.
+ */
+export async function getPostBySlug(
+  slug: string,
+  username: string = DEVTO_USERNAME,
+): Promise<ResolvedPost | null> {
+  const articles = await fetchDevtoArticles(username);
+  if (articles.length === 0) return null;
+  const meta = articles.find((a) => a.slug === slug);
+  if (!meta) return null;
+  const full = await fetchDevtoArticle(meta.id);
+  if (!full) return null;
+  return { meta, full };
+}
+
+/**
+ * All known post slugs. Used by `generateStaticParams` so each
+ * post page is statically generated at build time.
+ */
+export async function getAllPostSlugs(
+  username: string = DEVTO_USERNAME,
+): Promise<string[]> {
+  const articles = await fetchDevtoArticles(username);
+  return articles.map((a) => a.slug);
+}


### PR DESCRIPTION
Sprint 8 phase 2. Builds the in-site post-detail route on top of Phase 8.1's dev.to fetch. Visitors now read syndicated posts on m4rkyu.com without losing the dev.to attribution + reactions/comments link-out.

## What ships

- **deps**: \`react-markdown@^9.1.0\` + \`remark-gfm@^4.0.1\`. Server-only consumers — zero client-bundle impact.
- **\`src/lib/blog/get-post.ts\`** — \`getPostBySlug(slug)\` (slug → id → full article), \`getAllPostSlugs()\` for static params + sitemap.
- **\`src/components/blog/post-body.tsx\`** — \`react-markdown\` with a tokenized \`components\` map: editorial headings, ring-accent blockquote rule, mono code (inline chip + fenced \`<pre>\` wrapper), tables, and an \`img\` override that routes through \`next/image\` with figcaption. Inline-vs-fenced code detection uses the \`language-*\` class hint plus a newline fallback for unmarked fences.
- **\`src/components/blog/post-header.tsx\`** — cyber-grid + archive-vignette atmosphere; meta ribbon with date · reading time · reactions · comments; tag chips; "View on dev.to" + optional "Discuss" CTAs; optional cover image hero.
- **\`src/app/[locale]/blog/[slug]/page.tsx\`** — \`generateStaticParams\` per (locale, slug); \`generateMetadata\` sets \`alternates.canonical\` to the **dev.to URL** so search engines treat dev.to as source. \`openGraph.type=article\` with cover image. Body → "originally published" footer → \`CaseStudyFooter\` prev/next in archive (older → newer) reading order.
- **\`next.config.ts\`** gains image \`remotePatterns\` for \`media{,2,3}.dev.to\` and \`dev-to-uploads.s3.amazonaws.com\`.
- **Sitemap** is now async and emits \`/blog/<slug>\` per locale.
- **Card link target flip**: \`PostListItem\`, \`PinnedPostCard\`, \`WritingPulseRow\`, and the homepage status pulse all link back to in-site \`/blog/<slug>\` now that the route exists. The \`OpenLink\` helper in \`StatusPulseRow\` stays as defensive infra for future external entries.

## Test plan

- [x] \`npm run validate\` silent
- [ ] PR CI green (lint + typecheck + Playwright smoke)
- [ ] Vercel preview build succeeds (image \`remotePatterns\` change is the riskiest part)
- [ ] Manual: \`/en/blog/the-true-cost-of-poor-data-quality-2epi\` (or any current dev.to slug) renders the post in-site, body styled to brand, cover image renders via next/image
- [ ] View source: \`<link rel=\"canonical\" href=\"https://dev.to/markyu/...\">\` (NOT \`m4rkyu.com\`) on every post page
- [ ] Footer "View on dev.to" + "Continue on dev.to" both open in a new tab
- [ ] Prev / next adjacency walks older posts as "previous" — dev.to lists newest-first
- [ ] \`/sitemap.xml\` includes every \`/<locale>/blog/<slug>\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)