### PR TITLE
feat: phase-9 blog polish — bring /blog and /blog/[slug] to project-detail bar

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -182,7 +182,15 @@
     "metaDescription": "Writing and devlog from ZhenXiao Mark Yu — engineering notes, design process, and game development.",
     "tagAll": "All",
     "pinnedEyebrow": "Pinned",
-    "noMatches": "No posts match this tag."
+    "noMatches": "No posts match this tag.",
+    "archiveStatus": "Archive status",
+    "postsPublished": "posts published",
+    "syndicatedFrom": "syndicated from",
+    "syndicatedNote": "Posts are mirrored in-site daily. Reactions and comments live on dev.to.",
+    "relatedHeading": "Related reading",
+    "originallyPublished": "originally published",
+    "originallyPublishedNote": "This post first ran on dev.to. Comments and reactions live there.",
+    "continueOnDevto": "Continue on dev.to"
   },
   "About": {
     "title": "About Mark",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -182,7 +182,15 @@
     "metaDescription": "于震潇的写作与开发日志：工程随笔、设计过程与游戏开发。",
     "tagAll": "全部",
     "pinnedEyebrow": "置顶",
-    "noMatches": "没有匹配此标签的文章。"
+    "noMatches": "没有匹配此标签的文章。",
+    "archiveStatus": "档案状态",
+    "postsPublished": "篇已发布",
+    "syndicatedFrom": "同步自",
+    "syndicatedNote": "文章每日同步至此。点赞与评论保留在 dev.to。",
+    "relatedHeading": "相关阅读",
+    "originallyPublished": "原文发布",
+    "originallyPublishedNote": "本文首发于 dev.to，评论与点赞保留在原站。",
+    "continueOnDevto": "在 dev.to 继续阅读"
   },
   "About": {
     "title": "关于 Mark",

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ArrowUpRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { PageShell } from "@/components/layout/page-shell";
 import { PostHeader } from "@/components/blog/post-header";
 import { PostBody } from "@/components/blog/post-body";
+import { RelatedPosts } from "@/components/blog/related-posts";
 import { CaseStudyFooter } from "@/components/case-study/case-study-footer";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
 import type { Locale } from "@/i18n/routing";
 import { buildAlternates } from "@/lib/seo/alternates";
 import { getPostBySlug, getAllPostSlugs } from "@/lib/blog/get-post";
@@ -83,6 +86,7 @@ export default async function BlogPostPage({
   );
   const next = adjacentEntry(idx > 0 ? articles[idx - 1] : undefined);
 
+  const t = await getTranslations({ locale, namespace: "Blog" });
   const { meta, full } = resolved;
 
   return (
@@ -105,31 +109,48 @@ export default async function BlogPostPage({
           username={DEVTO_USERNAME}
         />
 
-        <section className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
-          <PostBody markdown={full.body_markdown} />
+        <section className="mx-auto w-full max-w-3xl bg-muted/10 px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
+          <BlurFade delay={0.05}>
+            <PostBody markdown={full.body_markdown} />
+          </BlurFade>
         </section>
 
-        <section className="mx-auto w-full max-w-3xl border-t px-4 py-10 sm:px-6 lg:px-8">
-          <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
-            originally published
-          </p>
-          <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              This post first ran on dev.to. Comments and reactions live there.
+        {/* Cascade order matches DOM order so the reveal reads
+         * top-to-bottom: body 0.05 → related 0.10 → originally 0.12
+         * → footer 0.15. */}
+        <BlurFade delay={0.1}>
+          <RelatedPosts
+            currentSlug={meta.slug}
+            currentTags={meta.tag_list}
+            articles={articles}
+          />
+        </BlurFade>
+
+        <BlurFade delay={0.12}>
+          <section className="mx-auto w-full max-w-3xl border-t px-4 py-10 sm:px-6 lg:px-8">
+            <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground">
+              {t("originallyPublished")}
             </p>
-            <a
-              href={meta.canonical_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
-            >
-              <span>Continue on dev.to</span>
-              <ArrowUpRight aria-hidden="true" className="size-3.5" />
-            </a>
-          </div>
-        </section>
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground">
+                {t("originallyPublishedNote")}
+              </p>
+              <a
+                href={meta.canonical_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                <span>{t("continueOnDevto")}</span>
+                <ArrowUpRight aria-hidden="true" className="size-3.5" />
+              </a>
+            </div>
+          </section>
+        </BlurFade>
 
-        <CaseStudyFooter prev={prev} next={next} archiveHref="/blog" />
+        <BlurFade delay={0.15}>
+          <CaseStudyFooter prev={prev} next={next} archiveHref="/blog" />
+        </BlurFade>
       </article>
     </PageShell>
   );

--- a/src/app/[locale]/blog/_client.tsx
+++ b/src/app/[locale]/blog/_client.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PostListItem } from "@/components/cards/post-list-item";
+import { Stagger, StaggerItem } from "@/components/motion/stagger";
 import type { Post } from "@/content/schemas";
 
 interface BlogTimelineProps {
@@ -91,11 +92,20 @@ export function BlogTimeline({ posts }: BlogTimelineProps) {
           {t("noMatches")}
         </p>
       ) : (
-        <ol className="mt-8 grid gap-1 divide-y divide-border/60">
+        <Stagger
+          // Re-key on tag change so the rows restagger smoothly when
+          // a chip flips. Same pattern as the projects archive.
+          key={`stagger-${activeTag}`}
+          as="ol"
+          className="mt-8 grid gap-1 divide-y divide-border/60"
+          delay={0.04}
+        >
           {filtered.map((post) => (
-            <PostListItem key={post.slug} post={post} />
+            <StaggerItem key={post.slug} as="li">
+              <PostListItem post={post} />
+            </StaggerItem>
           ))}
-        </ol>
+        </Stagger>
       )}
     </>
   );

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -4,9 +4,10 @@ import { PageShell } from "@/components/layout/page-shell";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { PinnedPostCard } from "@/components/cards/pinned-post-card";
 import { FadeIn } from "@/components/motion/fade-in";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Locale } from "@/i18n/routing";
 import { buildAlternates } from "@/lib/seo/alternates";
-import { getPosts } from "@/lib/blog/get-posts";
+import { getPosts, DEVTO_USERNAME } from "@/lib/blog/get-posts";
 import { BlogTimeline } from "./_client";
 
 export async function generateMetadata({
@@ -39,7 +40,7 @@ export default async function BlogPage({
       <section className="relative overflow-hidden border-b">
         <div className="absolute inset-0 bg-cyber-grid opacity-30" aria-hidden="true" />
         <div className="archive-vignette absolute inset-0" aria-hidden="true" />
-        <div className="relative mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_22rem] lg:px-8">
           <FadeIn>
             <SectionHeading
               as="h1"
@@ -47,6 +48,32 @@ export default async function BlogPage({
               title={t("title")}
               description={t("description")}
             />
+          </FadeIn>
+          <FadeIn direction="left" delay={0.1}>
+            <Card className="bg-background/70 backdrop-blur">
+              <CardHeader>
+                <CardTitle>{t("archiveStatus")}</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-3 text-sm text-muted-foreground">
+                <p>
+                  <span className="font-mono text-foreground">{posts.length}</span>{" "}
+                  {t("postsPublished")}
+                </p>
+                <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em]">
+                  {t("syndicatedFrom")}{" "}
+                  <a
+                    href={`https://dev.to/${DEVTO_USERNAME}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`dev.to profile, @${DEVTO_USERNAME}`}
+                    className="text-foreground underline-offset-4 hover:underline"
+                  >
+                    dev.to / @{DEVTO_USERNAME}
+                  </a>
+                </p>
+                <p>{t("syndicatedNote")}</p>
+              </CardContent>
+            </Card>
           </FadeIn>
         </div>
       </section>

--- a/src/components/blog/post-body.tsx
+++ b/src/components/blog/post-body.tsx
@@ -28,7 +28,10 @@ const components: Components = {
     <h1
       {...props}
       className={cn(
-        "mt-12 scroll-mt-24 font-[family-name:var(--font-display)] text-3xl font-semibold tracking-tight text-foreground sm:text-4xl",
+        // scroll-mt aligns anchored headings under the sticky site
+        // header (h-14 on <sm, h-16 above) plus a small breathing
+        // gap. Tightened from scroll-mt-24 to match case-study sections.
+        "mt-12 scroll-mt-20 font-[family-name:var(--font-display)] text-3xl font-semibold tracking-tight text-foreground sm:text-4xl",
         className,
       )}
     />
@@ -37,7 +40,7 @@ const components: Components = {
     <h2
       {...props}
       className={cn(
-        "mt-10 scroll-mt-24 font-[family-name:var(--font-display)] text-2xl font-semibold tracking-tight text-foreground sm:text-3xl",
+        "mt-10 scroll-mt-20 font-[family-name:var(--font-display)] text-2xl font-semibold tracking-tight text-foreground sm:text-3xl",
         className,
       )}
     />
@@ -46,7 +49,7 @@ const components: Components = {
     <h3
       {...props}
       className={cn(
-        "mt-8 scroll-mt-24 text-xl font-semibold leading-snug text-foreground",
+        "mt-8 scroll-mt-20 text-xl font-semibold leading-snug text-foreground",
         className,
       )}
     />
@@ -55,7 +58,7 @@ const components: Components = {
     <h4
       {...props}
       className={cn(
-        "mt-6 scroll-mt-24 text-lg font-semibold leading-snug text-foreground",
+        "mt-6 scroll-mt-20 text-lg font-semibold leading-snug text-foreground",
         className,
       )}
     />
@@ -151,16 +154,19 @@ const components: Components = {
     );
   },
   pre: ({ className, ...props }) => (
+    // `max-w-full` constrains the pre to the post body's column so a
+    // long unbreakable string scrolls horizontally inside the column
+    // rather than expanding the page on narrow viewports.
     <pre
       {...props}
       className={cn(
-        "mt-6 overflow-x-auto rounded-md border border-border bg-muted/50 p-4 font-mono text-sm leading-6",
+        "mt-6 max-w-full overflow-x-auto rounded-md border border-border bg-muted/50 p-4 font-mono text-sm leading-6",
         className,
       )}
     />
   ),
   table: ({ className, ...props }) => (
-    <div className="mt-6 overflow-x-auto">
+    <div className="mt-6 max-w-full overflow-x-auto rounded-md border border-border/70">
       <table
         {...props}
         className={cn(

--- a/src/components/blog/post-header.tsx
+++ b/src/components/blog/post-header.tsx
@@ -2,6 +2,8 @@ import { ArrowUpRight, Heart, MessageSquare } from "lucide-react";
 import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { ReadingProgress } from "@/components/blog/reading-progress";
 
 interface PostHeaderProps {
   title: string;
@@ -19,9 +21,9 @@ interface PostHeaderProps {
 /**
  * Editorial header for a syndicated dev.to post. Same atmospheric
  * stack as case-study and game detail headers (cyber-grid + archive
- * vignette), but the meta ribbon below the title surfaces dev.to-
- * specific signals: reactions, comments, and a "view on dev.to" CTA
- * that opens the canonical source in a new tab.
+ * vignette), with a meta ribbon that surfaces date, reading time,
+ * reactions, and comments. Renders a ring-color reading-progress
+ * bar fixed to the bottom edge of the sticky site header.
  */
 export function PostHeader({
   title,
@@ -37,6 +39,7 @@ export function PostHeader({
 }: PostHeaderProps) {
   return (
     <header className="relative overflow-hidden border-b">
+      <ReadingProgress />
       <div
         className="absolute inset-0 bg-cyber-grid opacity-30"
         aria-hidden="true"
@@ -55,12 +58,18 @@ export function PostHeader({
           {description}
         </p>
 
-        <dl className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+        {/* Meta ribbon. On <sm we drop the inline `·` separators in
+         * favor of a wrap-friendly chip stack so a long reading time
+         * never orphans the reactions count on the next line. */}
+        <dl className="mt-7 flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground sm:gap-x-5 sm:gap-y-2 sm:text-[0.65rem] sm:tracking-[0.2em]">
           <div className="flex items-center gap-2">
             <dt className="sr-only">Published</dt>
             <dd>{date}</dd>
           </div>
-          <span aria-hidden="true" className="text-muted-foreground/40">
+          <span
+            aria-hidden="true"
+            className="hidden text-muted-foreground/40 sm:inline"
+          >
             ·
           </span>
           <div className="flex items-center gap-2">
@@ -69,7 +78,10 @@ export function PostHeader({
           </div>
           {reactionsCount > 0 ? (
             <>
-              <span aria-hidden="true" className="text-muted-foreground/40">
+              <span
+                aria-hidden="true"
+                className="hidden text-muted-foreground/40 sm:inline"
+              >
                 ·
               </span>
               <div className="flex items-center gap-1.5">
@@ -81,7 +93,10 @@ export function PostHeader({
           ) : null}
           {commentsCount > 0 ? (
             <>
-              <span aria-hidden="true" className="text-muted-foreground/40">
+              <span
+                aria-hidden="true"
+                className="hidden text-muted-foreground/40 sm:inline"
+              >
                 ·
               </span>
               <div className="flex items-center gap-1.5">
@@ -139,17 +154,19 @@ export function PostHeader({
         </div>
 
         {cover ? (
-          <figure className="mt-10 overflow-hidden rounded-md border border-border">
-            <Image
-              src={cover.src}
-              alt={cover.alt}
-              width={1000}
-              height={420}
-              priority
-              sizes="(min-width: 768px) 768px, 100vw"
-              className="h-auto w-full"
-            />
-          </figure>
+          <BlurFade delay={0.05}>
+            <figure className="mt-10 aspect-16/10 overflow-hidden rounded-md border border-border bg-muted">
+              <Image
+                src={cover.src}
+                alt={cover.alt}
+                width={1000}
+                height={420}
+                priority
+                sizes="(min-width: 768px) 768px, 100vw"
+                className="h-full w-full object-cover"
+              />
+            </figure>
+          </BlurFade>
         ) : null}
       </div>
     </header>

--- a/src/components/blog/reading-progress.tsx
+++ b/src/components/blog/reading-progress.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { motion, useReducedMotion, useScroll, useSpring } from "motion/react";
+
+/**
+ * 2px-tall ring-color bar fixed under the sticky site header that
+ * tracks scroll progress through the post page.
+ *
+ * Honors `prefers-reduced-motion` by short-circuiting to `null` —
+ * the bar is purely ornamentation; reduced-motion users lose
+ * nothing functional. The spring smooths the scroll-driven motion
+ * so the bar glides instead of jittering on each frame.
+ */
+export function ReadingProgress() {
+  const reduceMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll();
+  const scaleX = useSpring(scrollYProgress, {
+    stiffness: 110,
+    damping: 22,
+    mass: 0.4,
+  });
+
+  // `useReducedMotion()` is tri-state — `null` until the media
+  // query resolves, then `true | false`. Treat anything other than
+  // an explicit `false` as "reduced" so the bar doesn't flash for
+  // one frame then unmount on first paint.
+  if (reduceMotion !== false) return null;
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      style={{ scaleX, transformOrigin: "0% 50%" }}
+      // Sticky header is h-14 (<sm) / h-16 (sm+); the progress bar
+      // anchors flush with its lower border on each breakpoint.
+      className="pointer-events-none fixed left-0 right-0 top-14 z-30 h-[2px] origin-left bg-ring/80 sm:top-16"
+    />
+  );
+}

--- a/src/components/blog/related-posts.tsx
+++ b/src/components/blog/related-posts.tsx
@@ -1,0 +1,93 @@
+import { getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import type { DevtoArticleListItem } from "@/lib/blog/devto";
+
+interface RelatedPostsProps {
+  currentSlug: string;
+  currentTags: readonly string[];
+  articles: readonly DevtoArticleListItem[];
+  limit?: number;
+}
+
+const eyebrowMono =
+  "font-mono text-[0.65rem] uppercase tracking-[0.24em] text-muted-foreground";
+
+/**
+ * Pick up to `limit` articles ordered by tag-overlap with the
+ * current post. Falls back to the next chronological articles
+ * (newest-first) if no overlap exists. The current article is
+ * always excluded.
+ */
+function pickRelated(
+  currentSlug: string,
+  currentTags: readonly string[],
+  articles: readonly DevtoArticleListItem[],
+  limit: number,
+): DevtoArticleListItem[] {
+  const others = articles.filter((article) => article.slug !== currentSlug);
+  const tagSet = new Set(currentTags);
+  if (tagSet.size === 0) {
+    return others.slice(0, limit);
+  }
+  const scored = others.map((article) => ({
+    article,
+    score: article.tag_list.reduce(
+      (count, tag) => (tagSet.has(tag) ? count + 1 : count),
+      0,
+    ),
+  }));
+  const overlapping = scored
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.article);
+  if (overlapping.length >= limit) return overlapping.slice(0, limit);
+  // Pad with the most recent non-overlapping articles. dev.to lists
+  // newest-first; preserve that order.
+  const seen = new Set(overlapping.map((a) => a.slug));
+  const filler = others
+    .filter((article) => !seen.has(article.slug))
+    .slice(0, limit - overlapping.length);
+  return [...overlapping, ...filler];
+}
+
+/**
+ * "Related" stack rendered after the post body. Reads directly off
+ * the dev.to article listing (not the schema-parsed `Post[]`) so it
+ * survives any per-row Zod parse failure that might drop posts from
+ * the timeline. Mirrors the project-detail "Related work" card grid.
+ */
+export async function RelatedPosts({
+  currentSlug,
+  currentTags,
+  articles,
+  limit = 3,
+}: RelatedPostsProps) {
+  const t = await getTranslations("Blog");
+  const related = pickRelated(currentSlug, currentTags, articles, limit);
+  if (related.length === 0) return null;
+
+  return (
+    <section className="mx-auto w-full max-w-3xl border-t px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
+      <h2 className={eyebrowMono}>{t("relatedHeading")}</h2>
+      <div className="mt-6 grid gap-4 md:grid-cols-2">
+        {related.map((article) => (
+          <Link
+            key={article.slug}
+            href={`/blog/${article.slug}`}
+            className="group rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            <p className="font-mono text-[0.6rem] uppercase tracking-[0.22em] text-muted-foreground">
+              {article.tag_list[0] ?? "post"}
+            </p>
+            <h3 className="mt-3 text-base font-semibold leading-snug text-foreground">
+              {article.title}
+            </h3>
+            <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">
+              {article.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/cards/pinned-post-card.tsx
+++ b/src/components/cards/pinned-post-card.tsx
@@ -1,4 +1,5 @@
 import { ArrowUpRight, Star } from "lucide-react";
+import Image from "next/image";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/placeholders/draft-badge";
@@ -10,17 +11,34 @@ interface PinnedPostCardProps {
 }
 
 const cardClass =
-  "group relative grid gap-4 overflow-hidden rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:p-8";
+  "group relative block overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+const bodyClass = "grid gap-4 p-6 sm:p-8";
 
 /**
  * One-per-site pinned essay slot at the top of /blog. Uses the
  * display family for the title; otherwise reads the same data shape
- * as PostListItem. Routes to `canonicalUrl` (dev.to) when set,
- * otherwise the in-site `/blog/[slug]` route.
+ * as PostListItem. Routes to the in-site `/blog/[slug]` detail
+ * route — Phase 8.2 ships in-site rendering for syndicated posts.
+ *
+ * When `coverImage` is set, the card grows a 16:10 hero above the
+ * meta row (mirrors `ProjectCard` rest/hover treatment).
  */
 export async function PinnedPostCard({ post }: PinnedPostCardProps) {
   const t = await getTranslations("Blog");
   const isDraft = post.status !== "ready";
+
+  const cover = post.coverImage ? (
+    <div className="relative aspect-16/10 overflow-hidden border-b bg-muted">
+      <Image
+        src={post.coverImage.src}
+        alt={post.coverImage.alt}
+        fill
+        sizes="(min-width: 1024px) 1024px, 100vw"
+        className="object-cover grayscale transition duration-500 group-hover:scale-[1.02] group-hover:grayscale-0"
+      />
+    </div>
+  ) : null;
 
   const body = (
     <>
@@ -67,7 +85,8 @@ export async function PinnedPostCard({ post }: PinnedPostCardProps) {
 
   return (
     <Link href={`/blog/${post.slug}`} className={cardClass}>
-      {body}
+      {cover}
+      <div className={bodyClass}>{body}</div>
     </Link>
   );
 }

--- a/src/components/cards/post-list-item.stories.tsx
+++ b/src/components/cards/post-list-item.stories.tsx
@@ -48,7 +48,9 @@ const longExcerptPost: Post = {
 function PostListItemStory({ post }: { post: Post }) {
   return (
     <ol className="grid gap-1 divide-y divide-border/60 max-w-3xl">
-      <PostListItem post={post} />
+      <li>
+        <PostListItem post={post} />
+      </li>
     </ol>
   );
 }

--- a/src/components/cards/post-list-item.tsx
+++ b/src/components/cards/post-list-item.tsx
@@ -1,4 +1,5 @@
 import { ArrowUpRight } from "lucide-react";
+import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/placeholders/draft-badge";
 import { LinkPreview } from "@/components/system/link-preview";
@@ -37,93 +38,119 @@ function RowLink({
 }
 
 /**
- * Single timeline row for /blog. The whole row is one Link — no
- * nested interactive elements. Mono date column on md+; on mobile,
- * date and reading time co-locate on a single meta line above the
- * title. Hover lifts background subtly; on desktop, hovering or
- * keyboard-focusing also surfaces a `LinkPreview` with cover and
- * excerpt.
+ * Single timeline row for /blog. The row is a single Link — no
+ * nested interactive elements. The outer `<li>` is intentionally
+ * NOT included here so the consumer can wrap with `<StaggerItem
+ * as="li">` for the timeline filter restagger orchestration.
+ *
+ * Layout:
+ * - <md: date + reading time stack on a single meta line above the title.
+ * - md: 3-col grid → mono-date column · content · reading time.
+ * - lg + cover: 4-col grid → 4:3 thumbnail · date · content · reading time.
+ *
+ * Hover lifts the background subtly; the `LinkPreview` tooltip
+ * surfaces the full cover + lede on desktop.
  */
 export function PostListItem({ post }: PostListItemProps) {
   const isDraft = post.status !== "ready";
+  const hasCover = Boolean(post.coverImage);
   return (
-    <li>
-      <LinkPreview
-        title={post.title}
-        lede={post.excerpt}
-        eyebrow={post.category}
-        image={post.coverImage}
-        placeholderLabel="POST COVER TBD"
-        side="right"
-        align="start"
+    <LinkPreview
+      title={post.title}
+      lede={post.excerpt}
+      eyebrow={post.category}
+      image={post.coverImage}
+      placeholderLabel="POST COVER TBD"
+      side="right"
+      align="start"
+    >
+      <RowLink
+        post={post}
+        className={cn(
+          "group grid gap-3 rounded-lg border border-transparent px-4 py-5 transition-colors duration-(--motion-fast) ease-(--ease-premium)",
+          "hover:border-border hover:bg-muted/30",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "md:items-center md:gap-6",
+          hasCover
+            ? "md:grid-cols-[8rem_1fr_auto] lg:grid-cols-[8rem_8rem_1fr_auto]"
+            : "md:grid-cols-[8rem_1fr_auto]",
+        )}
       >
-        <RowLink
-          post={post}
+        {/* lg-only thumbnail (only when a cover exists). Hidden on
+         * mobile / md to keep the timeline text-first; on lg the row
+         * reads as a contact sheet. */}
+        {hasCover && post.coverImage ? (
+          <div
+            aria-hidden="true"
+            className="relative hidden aspect-4/3 w-32 overflow-hidden rounded-md border border-border bg-muted lg:block"
+          >
+            <Image
+              src={post.coverImage.src}
+              alt=""
+              fill
+              sizes="128px"
+              className="object-cover grayscale transition duration-500 group-hover:scale-[1.04] group-hover:grayscale-0"
+            />
+          </div>
+        ) : null}
+
+        {/* Mobile-only meta line: date · reading time */}
+        <div
           className={cn(
-            "group grid gap-3 rounded-lg border border-transparent px-4 py-5 transition-colors duration-(--motion-fast) ease-(--ease-premium)",
-            "hover:border-border hover:bg-muted/30",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-            "md:grid-cols-[8rem_1fr_auto] md:items-baseline md:gap-6",
+            "flex flex-wrap items-center gap-x-3 gap-y-1",
+            "md:hidden",
           )}
         >
-          {/* Mobile-only meta line: date · reading time */}
-          <div
-            className={cn(
-              "flex flex-wrap items-center gap-x-3 gap-y-1",
-              "md:hidden",
-            )}
-          >
-            <span className={monoMeta}>{post.date}</span>
-            <span aria-hidden="true" className="text-muted-foreground/40">
-              ·
-            </span>
-            <span className={monoMeta}>{post.readingTime}</span>
-          </div>
-
-          {/* Desktop-only: standalone date column */}
-          <span className={cn(monoMeta, "hidden md:inline")}>{post.date}</span>
-
-          <div className="grid gap-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className={monoMeta}>{post.category}</span>
-              {isDraft ? <DraftBadge label={post.status} /> : null}
-            </div>
-            <h3 className="text-lg font-semibold leading-snug text-foreground">
-              {post.title}
-              <ArrowUpRight
-                aria-hidden="true"
-                className="ml-1 inline size-4 -translate-y-0.5 text-muted-foreground transition-transform duration-(--motion-fast) group-hover:-translate-y-1.5 group-hover:translate-x-0.5 group-hover:text-foreground"
-              />
-            </h3>
-            <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
-              {post.excerpt}
-            </p>
-            {post.tags.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5">
-                {post.tags.map((tag) => (
-                  <Badge
-                    key={tag}
-                    variant="outline"
-                    className="text-[0.6rem] lowercase tracking-[0.1em]"
-                  >
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
-            ) : null}
-          </div>
-
-          {/* Desktop-only: reading time, right-aligned */}
-          <span
-            className={cn(
-              monoMeta,
-              "hidden shrink-0 md:inline md:text-right",
-            )}
-          >
-            {post.readingTime}
+          <span className={monoMeta}>{post.date}</span>
+          <span aria-hidden="true" className="text-muted-foreground/40">
+            ·
           </span>
-        </RowLink>
-      </LinkPreview>
-    </li>
+          <span className={monoMeta}>{post.readingTime}</span>
+        </div>
+
+        {/* Desktop-only: standalone date column */}
+        <span className={cn(monoMeta, "hidden md:inline")}>{post.date}</span>
+
+        <div className="grid gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={monoMeta}>{post.category}</span>
+            {isDraft ? <DraftBadge label={post.status} /> : null}
+          </div>
+          <h3 className="text-lg font-semibold leading-snug text-foreground">
+            {post.title}
+            <ArrowUpRight
+              aria-hidden="true"
+              className="ml-1 inline size-4 -translate-y-0.5 text-muted-foreground transition-transform duration-(--motion-fast) group-hover:-translate-y-1.5 group-hover:translate-x-0.5 group-hover:text-foreground"
+            />
+          </h3>
+          <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+            {post.excerpt}
+          </p>
+          {post.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {post.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className="text-[0.6rem] lowercase tracking-[0.1em]"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {/* Desktop-only: reading time, right-aligned */}
+        <span
+          className={cn(
+            monoMeta,
+            "hidden shrink-0 md:inline md:text-right",
+          )}
+        >
+          {post.readingTime}
+        </span>
+      </RowLink>
+    </LinkPreview>
   );
 }

--- a/src/components/motion/stagger.tsx
+++ b/src/components/motion/stagger.tsx
@@ -27,20 +27,35 @@ const item: Variants = {
   },
 }
 
+type StaggerTag = "div" | "ol" | "ul" | "section"
+
 interface StaggerProps {
   children: React.ReactNode
   delay?: number
   className?: string
   once?: boolean
+  /**
+   * Render tag for the staggered container. Defaults to `"div"`.
+   * Use `"ol"` / `"ul"` when the staggered children are list rows
+   * so the resulting DOM stays semantically valid.
+   */
+  as?: StaggerTag
 }
 
-export function Stagger({ children, delay = 0, className, once = true }: StaggerProps) {
-  const ref = useRef<HTMLDivElement>(null)
+export function Stagger({
+  children,
+  delay = 0,
+  className,
+  once = true,
+  as = "div",
+}: StaggerProps) {
+  const ref = useRef<HTMLElement | null>(null)
   const isInView = useInView(ref, { once, margin: "-80px 0px" })
+  const Comp = motion[as] as typeof motion.div
 
   return (
-    <motion.div
-      ref={ref}
+    <Comp
+      ref={ref as React.Ref<HTMLDivElement>}
       variants={container}
       initial="hidden"
       animate={isInView ? "visible" : "hidden"}
@@ -48,14 +63,25 @@ export function Stagger({ children, delay = 0, className, once = true }: Stagger
       className={cn(className)}
     >
       {children}
-    </motion.div>
+    </Comp>
   )
 }
 
-export function StaggerItem({ children, className }: { children: React.ReactNode; className?: string }) {
+type StaggerItemTag = "div" | "li"
+
+export function StaggerItem({
+  children,
+  className,
+  as = "div",
+}: {
+  children: React.ReactNode
+  className?: string
+  as?: StaggerItemTag
+}) {
+  const Comp = motion[as] as typeof motion.div
   return (
-    <motion.div variants={item} className={cn(className)}>
+    <Comp variants={item} className={cn(className)}>
       {children}
-    </motion.div>
+    </Comp>
   )
 }


### PR DESCRIPTION
The dev.to syndication shipped functional but sparse in Sprint 8. Phase 9 raises the polish to match the case-study editorial template at \`/projects/[slug]\` so syndicated posts read as part of the brand, not grafted-on content.

## What ships

**Bucket 1 — Timeline composition**
- \`/blog\` hero gains \`lg:grid-cols-[1fr_22rem]\` split with a sidebar archive-status \`Card\` (post count + dev.to attribution + sync note).
- \`BlogTimeline\` wraps the row list in \`<Stagger as=\"ol\">\` + \`<StaggerItem as=\"li\">\`. Re-keys on \`activeTag\` so chip clicks restagger.
- \`Stagger\` / \`StaggerItem\` gain optional \`as\` props.
- \`PinnedPostCard\` grows a 16:10 cover hero above the body when \`coverImage\` is set.
- \`PostListItem\` gets an optional 4:3 thumbnail at \`lg+\` when \`coverImage\` is set.

**Bucket 2 — Detail entrance + cover ritual**
- Cover figure in \`PostHeader\` wrapped in \`BlurFade\` and locked to \`aspect-16/10\` so it doesn't reflow on narrow viewports.
- \`PostBody\`, \`RelatedPosts\`, \"originally published\" footer, and \`CaseStudyFooter\` each in \`BlurFade\` with **monotonic** delay cascade matching DOM order: \`0.05 → 0.10 → 0.12 → 0.15\`.

**Bucket 3 — Related posts**
- New \`src/components/blog/related-posts.tsx\`. Picks up to 3 articles by tag-overlap with the current post; falls back to next chronological when no overlap. **Reads off the raw dev.to article listing** (not schema-parsed \`Post[]\`) so a per-row Zod parse failure can't silently skip the related strip.

**Bucket 4 — Reading progress**
- New \`src/components/blog/reading-progress.tsx\`. 2px-tall ring-color bar fixed at \`top-14 sm:top-16\`, driven by \`useScroll\` + \`useSpring\`. Treats \`useReducedMotion\`'s \`null\` tri-state as reduced so the bar never flashes for one frame on first paint.

**Bucket 5 — Responsive + visual hygiene**
- \`PostHeader\` meta ribbon: drop inline \`·\` on \`<sm\`, gap-y-1.5 wrap; tighten typography one step.
- \`PostBody\` headings: \`scroll-mt-20\` (matches case-study sections).
- \`PostBody\` \`<pre>\` + table wrapper: \`max-w-full\` for narrow viewport overflow.
- \`/blog/[slug]\` body section: \`bg-muted/10\` band so cyber-grid hero → body transition reads as one composition.
- dev.to profile link gets \`aria-label\`.

**Translations** — \`Blog\` namespace gains 8 new keys, CJK hand-translated.

## Test plan

- [x] \`npm run validate\` silent
- [ ] PR CI green (lint + typecheck + Playwright smoke)
- [ ] \`/en/blog\` desktop xl+ — sidebar status card + tag chips + Stagger row entry; tag click restaggers smoothly
- [ ] \`/en/blog\` 360px — single-column, no horizontal overflow, meta wraps without orphan reading time
- [ ] \`/en/blog/<slug>\` — cover BlurFades in; reading-progress bar tracks scroll; PostBody fades in; related strip shows tag-overlapping posts
- [ ] DevTools \`prefers-reduced-motion: reduce\` — Stagger / BlurFade / progress bar all short-circuit
- [ ] Light + dark — pinned card cover, sidebar Card backdrop, body bg-muted/10 band all read cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)