### PR TITLE
feat(pixel): primitive components

### DIFF
--- a/src/components/ui/pixel/pixel-button.stories.tsx
+++ b/src/components/ui/pixel/pixel-button.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PixelButton } from "./pixel-button";
+
+const meta = {
+  title: "ui/pixel/PixelButton",
+  component: PixelButton,
+  args: {
+    children: "Browse the work",
+  },
+} satisfies Meta<typeof PixelButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Caret: Story = {
+  args: { glyph: "caret" },
+};
+
+export const Play: Story = {
+  args: { glyph: "play", variant: "secondary" },
+};
+
+export const Send: Story = {
+  args: { glyph: "send", variant: "outline", children: "Open a channel" },
+};
+
+export const Ghost: Story = {
+  args: { glyph: "caret", variant: "ghost", children: "Read the logs" },
+};
+
+export const Link: Story = {
+  args: { glyph: "caret", variant: "link", children: "View résumé" },
+};
+
+export const Disabled: Story = {
+  args: { glyph: "caret", disabled: true },
+};

--- a/src/components/ui/pixel/pixel-button.tsx
+++ b/src/components/ui/pixel/pixel-button.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Button, type ButtonProps } from "../button";
+import { cn } from "@/lib/utils";
+
+type Glyph = "caret" | "play" | "send";
+type Sound = "click" | "confirm";
+
+const GLYPHS: Record<Glyph, string> = {
+  caret: ">",
+  play: "▶",
+  send: "↵",
+};
+
+export interface PixelButtonProps extends ButtonProps {
+  /** Optional leading VT323 glyph that slides in on hover. */
+  glyph?: Glyph;
+  /**
+   * UI sound cue to emit on press. Prop is accepted in Phase 2 but
+   * not yet wired — Phase 7 adds the Web Audio module + SoundToggle.
+   * See docs/UNIFIED_VISUAL_DIRECTION.md §8.
+   */
+  sound?: Sound;
+}
+
+export const PixelButton = React.forwardRef<HTMLButtonElement, PixelButtonProps>(
+  // `sound` is accepted in Phase 2 but unused — destructured here so
+  // it never reaches `...rest` and lands on <button> as a stray DOM
+  // attribute. Phase 7 (Web Audio module + SoundToggle) will swap the
+  // unused destructure for an `useUiSound(sound)` hook fired on click.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Phase 7 stub
+  ({ glyph, sound, className, children, ...rest }, ref) => {
+    return (
+      <Button
+        ref={ref}
+        // `transition` covers transform AND colors (both in v4's default
+        // property set), so the press scale + the inherited hover-color
+        // animation share one timing function. `active:scale-[0.98]` is
+        // the "confirm" press from §7.2.
+        className={cn(
+          "group transition duration-(--motion-micro) ease-(--ease-premium) active:scale-[0.98]",
+          className,
+        )}
+        {...rest}
+      >
+        {glyph ? (
+          <span
+            aria-hidden="true"
+            className="font-pixel text-base leading-none opacity-60 transition duration-(--motion-fast) ease-(--ease-premium) group-hover:translate-x-0.5 group-hover:opacity-100"
+          >
+            {GLYPHS[glyph]}
+          </span>
+        ) : null}
+        {children}
+      </Button>
+    );
+  },
+);
+PixelButton.displayName = "PixelButton";

--- a/src/components/ui/pixel/pixel-panel.stories.tsx
+++ b/src/components/ui/pixel/pixel-panel.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PixelPanel } from "./pixel-panel";
+
+const meta = {
+  title: "ui/pixel/PixelPanel",
+  component: PixelPanel,
+  args: {
+    children:
+      "Premium cyber-pixel surface for HUD chips, terminal previews, and mission content.",
+  },
+} satisfies Meta<typeof PixelPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithTitle: Story = {
+  args: {
+    eyebrow: "system · status",
+    title: "M4RKYU.SYS",
+  },
+};
+
+export const InkTone: Story = {
+  args: {
+    eyebrow: "ink · panel",
+    title: "Inverted surface",
+    tone: "ink",
+  },
+};
+
+export const WithNotch: Story = {
+  args: {
+    eyebrow: "notched · corner",
+    title: "Cartridge corner",
+    notch: true,
+  },
+};

--- a/src/components/ui/pixel/pixel-panel.tsx
+++ b/src/components/ui/pixel/pixel-panel.tsx
@@ -1,0 +1,97 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const pixelPanelVariants = cva(
+  "relative rounded-sm border border-border",
+  {
+    variants: {
+      tone: {
+        default: "bg-card text-card-foreground",
+        // Inverted surface — `--surface-ink` flips between dark/light by
+        // theme (see globals.css :root vs [data-theme="dark"]), so the
+        // panel always reads as a stamped surface against the page.
+        ink: "bg-[var(--surface-ink)] text-[var(--surface-paper)] border-transparent",
+      },
+    },
+    defaultVariants: {
+      tone: "default",
+    },
+  },
+);
+
+// Top-right corner notch — kept off below `sm:` to avoid awkward clipping
+// on narrow viewports. The 12px polygon is the cartridge-corner motif
+// referenced in docs/UNIFIED_VISUAL_DIRECTION.md §4.5.
+const NOTCH_CLASS =
+  "sm:[clip-path:polygon(0_0,calc(100%-12px)_0,100%_12px,100%_100%,0_100%)]";
+
+export interface PixelPanelProps
+  extends React.HTMLAttributes<HTMLElement>,
+    VariantProps<typeof pixelPanelVariants> {
+  /**
+   * Title-bar headline rendered in VT323. Promotes the wrapper to
+   * `<section aria-labelledby>`. ASCII-friendly only — mixed-script
+   * titles (e.g. "Project 项目") render the non-Latin portion in the
+   * fallback font; for fully Chinese titles the `:lang(zh)` guard in
+   * globals.css already redirects `--font-pixel` to the display stack.
+   */
+  title?: string;
+  /** Short uppercase mono eyebrow on the left side of the title bar. */
+  eyebrow?: string;
+  /** Render a 12px cartridge corner notch on the top-right (sm+). */
+  notch?: boolean;
+}
+
+export function PixelPanel({
+  title,
+  eyebrow,
+  tone,
+  notch = false,
+  className,
+  children,
+  ...rest
+}: PixelPanelProps) {
+  const titleId = React.useId();
+  const hasHeader = Boolean(title || eyebrow);
+  const Element: React.ElementType = title ? "section" : "div";
+
+  return (
+    <Element
+      aria-labelledby={title ? titleId : undefined}
+      className={cn(
+        pixelPanelVariants({ tone }),
+        notch && NOTCH_CLASS,
+        className,
+      )}
+      {...rest}
+    >
+      {hasHeader ? (
+        <header className="flex items-center justify-between gap-3 border-b border-border/60 px-4 py-2">
+          {/* Left cluster — eyebrow + title share a baseline-aligned flex
+            * row so the layout collapses cleanly when only one is supplied
+            * (no empty spacer pushing the title to the right edge). */}
+          <div className="flex items-baseline gap-3">
+            {eyebrow ? (
+              <span className="font-mono text-[0.7rem] uppercase tracking-[0.18em] text-muted-foreground">
+                {eyebrow}
+              </span>
+            ) : null}
+            {title ? (
+              <h2
+                id={titleId}
+                className="font-pixel text-base normal-case tracking-normal text-foreground"
+              >
+                {title}
+              </h2>
+            ) : null}
+          </div>
+          {/* Right slot — empty in Phase 2. Phase 6 (StatusPulse) lands
+            * the live/now indicator here without disturbing layout. */}
+          <span aria-hidden="true" />
+        </header>
+      ) : null}
+      <div className="p-4">{children}</div>
+    </Element>
+  );
+}

--- a/src/components/ui/pixel/section-frame.stories.tsx
+++ b/src/components/ui/pixel/section-frame.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SectionFrame } from "./section-frame";
+import { Button } from "../button";
+
+const meta = {
+  title: "ui/pixel/SectionFrame",
+  component: SectionFrame,
+  args: {
+    title: "Systems & surfaces",
+  },
+} satisfies Meta<typeof SectionFrame>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithIndexAndEyebrow: Story = {
+  args: {
+    index: "05",
+    eyebrow: "selected · missions",
+    title: "Featured mission modules",
+    lede: "A small, curated archive of production interfaces, interactive systems, and visual experiments.",
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    index: "01",
+    eyebrow: "writing · logs",
+    title: "Field notes",
+    actions: (
+      <Button variant="outline" size="sm">
+        View all
+      </Button>
+    ),
+  },
+};
+
+export const PanelFrame: Story = {
+  args: {
+    index: "02",
+    eyebrow: "interface · systems",
+    title: "Bordered section opener",
+    lede: "Use frame=\"panel\" when the opener should sit on a bordered surface — game-lab subsections, contact CTA, etc.",
+    frame: "panel",
+  },
+};

--- a/src/components/ui/pixel/section-frame.tsx
+++ b/src/components/ui/pixel/section-frame.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { cn } from "@/lib/utils";
+
+type FrameMode = "default" | "panel";
+
+export interface SectionFrameProps {
+  /** Mono numerical index glyph (e.g. "01"). Rendered in VT323 before the title. */
+  index?: string;
+  /** Short uppercase mono eyebrow (e.g. "selected · missions"). */
+  eyebrow?: string;
+  title: string;
+  /** One-paragraph lede under the title. */
+  lede?: string;
+  /** Inline actions rendered on the right (typically a small CTA group). */
+  actions?: React.ReactNode;
+  /** "panel" wraps the header in a bordered surface for sub-sections. */
+  frame?: FrameMode;
+  className?: string;
+}
+
+export function SectionFrame({
+  index,
+  eyebrow,
+  title,
+  lede,
+  actions,
+  frame = "default",
+  className,
+}: SectionFrameProps) {
+  return (
+    // BlurFade lives INSIDE the <header> so the landmark stays at the
+    // outer DOM level — parent layouts can target the header with
+    // id / aria-labelledby without piercing the motion wrapper.
+    <header
+      className={cn(
+        "flex flex-col gap-3 md:flex-row md:items-end md:justify-between",
+        frame === "panel" &&
+          "rounded-sm border border-border bg-card px-5 py-4",
+        className,
+      )}
+    >
+      <BlurFade className="flex max-w-3xl flex-col gap-2">
+        {(index || eyebrow) ? (
+          <div className="flex flex-wrap items-baseline gap-3">
+            {index ? (
+              <span
+                aria-hidden="true"
+                className="font-pixel text-xl leading-none text-muted-foreground"
+              >
+                {index}
+              </span>
+            ) : null}
+            {eyebrow ? (
+              <span className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+                {eyebrow}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+        <h2 className="font-display text-balance text-3xl font-bold leading-[1.05] tracking-normal sm:text-4xl lg:text-5xl">
+          {title}
+        </h2>
+        {lede ? (
+          <p className="mt-1 max-w-2xl text-base leading-7 text-muted-foreground">
+            {lede}
+          </p>
+        ) : null}
+      </BlurFade>
+      {actions ? (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/ui/pixel/system-badge.stories.tsx
+++ b/src/components/ui/pixel/system-badge.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SystemBadge } from "./system-badge";
+
+const meta = {
+  title: "ui/pixel/SystemBadge",
+  component: SystemBadge,
+} satisfies Meta<typeof SystemBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = { args: { status: "ready" } };
+export const Draft: Story = { args: { status: "draft" } };
+export const Placeholder: Story = { args: { status: "placeholder" } };
+export const ComingSoon: Story = { args: { status: "coming-soon" } };
+
+export const Live: Story = { args: { kind: "live" } };
+export const Now: Story = { args: { kind: "now" } };
+export const Wip: Story = { args: { kind: "wip" } };
+export const Archive: Story = { args: { kind: "archive" } };
+export const Info: Story = { args: { kind: "info" } };
+
+export const CustomLabel: Story = {
+  args: { kind: "info", label: "v2027" },
+};

--- a/src/components/ui/pixel/system-badge.tsx
+++ b/src/components/ui/pixel/system-badge.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import type { z } from "zod";
+import { Badge } from "../badge";
+import { cn } from "@/lib/utils";
+import { contentStatusSchema } from "@/content/schemas";
+
+type ContentStatus = z.infer<typeof contentStatusSchema>;
+type SystemKind = "live" | "now" | "wip" | "archive" | "info";
+type Tone = "success" | "warning" | "signal" | "muted";
+
+const STATUS_TONE: Record<ContentStatus, Tone> = {
+  ready: "success",
+  draft: "warning",
+  placeholder: "muted",
+  "coming-soon": "muted",
+};
+
+const KIND_TONE: Record<SystemKind, Tone> = {
+  live: "signal",
+  now: "success",
+  wip: "warning",
+  archive: "muted",
+  info: "muted",
+};
+
+const STATUS_LABEL: Record<ContentStatus, string> = {
+  ready: "Ready",
+  draft: "Draft",
+  placeholder: "Pending",
+  "coming-soon": "Soon",
+};
+
+const KIND_LABEL: Record<SystemKind, string> = {
+  live: "Live",
+  now: "Now",
+  wip: "WIP",
+  archive: "Archive",
+  info: "Info",
+};
+
+const DOT_CLASS: Record<Tone, string> = {
+  success: "bg-success",
+  warning: "bg-warning",
+  signal: "bg-signal",
+  muted: "bg-muted-foreground",
+};
+
+export interface SystemBadgeProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Content schema status — drives the dot tone and default label. */
+  status?: ContentStatus;
+  /** System kind — alternative to `status` for non-content surfaces. */
+  kind?: SystemKind;
+  /** Override the auto-derived label (e.g. version tag, custom tag). */
+  label?: string;
+}
+
+export function SystemBadge({
+  status,
+  kind,
+  label,
+  className,
+  ...rest
+}: SystemBadgeProps) {
+  const tone: Tone = status
+    ? STATUS_TONE[status]
+    : kind
+      ? KIND_TONE[kind]
+      : "muted";
+  const resolved =
+    label ??
+    (status ? STATUS_LABEL[status] : kind ? KIND_LABEL[kind] : "Info");
+  // `live` and `now` will pulse in Phase 6 via the dedicated StatusPulse
+  // primitive. For now the dot is static; the accessibility hooks are
+  // already in place so AT users hear updates once the visual pulse lands.
+  const isLive = kind === "live" || kind === "now";
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn("gap-1.5 font-pixel", className)}
+      role={isLive ? "status" : undefined}
+      aria-live={isLive ? "polite" : undefined}
+      {...rest}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("size-1.5 rounded-full", DOT_CLASS[tone])}
+      />
+      <span>{resolved}</span>
+    </Badge>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 of [docs/UNIFIED_VISUAL_DIRECTION.md](docs/UNIFIED_VISUAL_DIRECTION.md) — the four foundation primitives the rest of the pixel layer composes on top of. Lives in a new [src/components/ui/pixel/](src/components/ui/pixel/) folder, mirroring the existing `magic/` subfolder. No pages migrated.

- **[PixelPanel](src/components/ui/pixel/pixel-panel.tsx)** — bordered "system panel" with optional title bar, ink-tone variant, and optional 12px cartridge corner notch (sm+). Promotes to `<section aria-labelledby>` when titled.
- **[PixelButton](src/components/ui/pixel/pixel-button.tsx)** — wraps `Button`, adds `glyph` (caret/play/send) that slides in on hover at `--motion-fast`. Press scales `0.98` at `--motion-micro`. The `sound` prop is accepted but no-op until Phase 7 wires the Web Audio module.
- **[SystemBadge](src/components/ui/pixel/system-badge.tsx)** — wraps `Badge`, drives tone + label from either `contentStatusSchema` (`ready` / `draft` / `placeholder` / `coming-soon`) or a `SystemKind` (`live` / `now` / `wip` / `archive` / `info`). Live/now states already wear `role=\"status\"` `aria-live=\"polite\"` so Phase 6's StatusPulse can land without an a11y rewrite.
- **[SectionFrame](src/components/ui/pixel/section-frame.tsx)** — Lambda-style numbered section opener (`index` + `eyebrow` + `title` + `lede` + `actions`, with an optional `panel` frame). Wraps inner content in `BlurFade`; the `<header>` landmark stays at the outer DOM level so parents can address it.

Each component has a matching `*.stories.tsx` (default / variants / disabled / panel-frame / custom-label) — eight new files total.

## Token consumption

- `font-pixel` utility everywhere a pixel glyph appears (caret, index, dot label, panel title). The `:lang(zh)` guard from Phase 1 handles CJK pages automatically.
- `transition duration-(--motion-fast | --motion-micro) ease-(--ease-premium)` for hover and press; **no** `transition-[colors,transform]`.
- `bg-card`, `border-border`, `text-muted-foreground`, `bg-success` / `bg-warning` / `bg-signal` / `bg-muted-foreground` for the SystemBadge dot. No hex literals, no `bg-zinc-*`.

## Deferred to later phases

- Sound playback (Phase 7 — Web Audio + `SoundToggle`).
- `StatusPulse` on `live` / `now` dots (Phase 6 — microinteractions).
- Page migrations (Phase 3 onward — `CommandHero`, `GameHud`, `MissionModuleCard`, …).

## Validation results

- ✅ `npm run validate` — silent (lint + typecheck).
- ✅ `npm run build-storybook` — clean, built in 5.07s.
- ✅ `npm run test:e2e` — **96 / 96 passed** in 2.3 min across 360 / 390 / 768 / 1280 / 1920 + Chromium.

## Code-reviewer pass

Pre-commit `code-reviewer` subagent reported **1 BLOCK / 4 SHOULD-FIX / 4 NIT**. All BLOCK + 3 SHOULD-FIX + 1 NIT applied in-branch before commit. Pushed back on one SHOULD-FIX (\"add `\"use client\"` to SectionFrame\") because [BlurFade](src/components/ui/magic/blur-fade.tsx) is already a client leaf — SectionFrame correctly stays a server component, and the client boundary lives at BlurFade, not at the consumer.

**Applied:**
- PixelPanel title bar restructured — eyebrow + title now share a baseline-aligned left cluster instead of `justify-between` with an empty spacer, so the title doesn't jump to the right edge when `eyebrow` is omitted.
- SectionFrame's `<header>` landmark lifted outside `BlurFade` so parents can target it with `id` / `aria-labelledby`.
- `PixelButton.displayName = \"PixelButton\"` added for lint + devtools consistency with the existing `forwardRef` primitives (Button, Input, Command*).
- PixelPanel `title` documented as ASCII-friendly; CJK titles fall through the `:lang(zh)` guard from Phase 1, mixed-script titles render non-Latin glyphs in the fallback font.
- `sound` destructure on PixelButton silenced with a tightly-scoped `eslint-disable-next-line` (project's `eslint-config-next` doesn't ship `argsIgnorePattern`; adding it for one prop is scope creep).

## Test plan

- [x] `npm run validate` passes silently.
- [x] `npm run build-storybook` passes; all four new stories render.
- [x] `npm run test:e2e` passes the full route matrix (no page change, but confirms no regression from the new files being scanned).
- [x] No new dependencies added.
- [x] No `next.config.ts` / `tsconfig.json` / `package.json` changes.
- [x] No page or route changes (Phase 2 boundary respected).
- [ ] *Follow-up PR (Phase 3)*: ship `CommandHero` + `GameHud` and migrate the homepage hero to consume the new primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)