### PR TITLE
feat(home): CommandHero + GameHud

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -25,9 +25,12 @@
     "switchTo": "Switch to {target}"
   },
   "Home": {
-    "eyebrow": "M4rkyu.com / 2027 remake",
-    "title": "ZhenXiao Mark Yu",
-    "subtitle": "Software engineer, frontend systems builder, game developer, and digital artist building precise interfaces with cinematic restraint.",
+    "eyebrow": "M4RKYU.SYS · v2027",
+    "title": "One archive. Software, art, games.",
+    "subtitle": "Software engineer, game developer, and visual archivist. This site collects the work, the logs, and a small set of tools that earn their keep.",
+    "heroCtaBrowse": "Browse the work",
+    "heroCtaLogs": "Read the logs",
+    "heroCmdkHint": ">_ press ⌘K",
     "primaryCta": "View projects",
     "portalCta": "Enter portal",
     "featured": "Featured case studies",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -25,9 +25,12 @@
     "switchTo": "切换到 {target}"
   },
   "Home": {
-    "eyebrow": "M4rkyu.com / 2027 重制",
-    "title": "ZhenXiao Mark Yu",
-    "subtitle": "软件工程师、前端系统构建者、游戏开发者与数字艺术创作者。用克制的电影感，打磨清晰、可靠、有质感的界面。",
+    "eyebrow": "M4RKYU.SYS · v2027",
+    "title": "一份档案。软件、艺术、游戏。",
+    "subtitle": "软件工程师，游戏开发者，视觉记录者。这里收录作品、日志，以及为自己写的小工具。",
+    "heroCtaBrowse": "浏览作品",
+    "heroCtaLogs": "阅读日志",
+    "heroCmdkHint": ">_ 按 ⌘K",
     "primaryCta": "查看项目",
     "portalCta": "进入 Portal",
     "featured": "精选案例",

--- a/src/components/sections/command-hero.tsx
+++ b/src/components/sections/command-hero.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { PixelPanel } from "@/components/ui/pixel/pixel-panel";
+import { SystemBadge } from "@/components/ui/pixel/system-badge";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+
+interface CommandHeroStatus {
+  /** Short label shown next to the live dot (e.g. project title). */
+  label: string;
+  /** Optional internal href the label links to. */
+  href?: string;
+  /** Optional accessible label override. Defaults to `Open ${label}`. */
+  accessibleLabel?: string;
+}
+
+interface CommandHeroProps {
+  /** Optional live data point — typically the latest shipping project. */
+  status?: CommandHeroStatus;
+  /**
+   * ASCII / VT323 brand mark rendered in the panel body. Defaults to a
+   * static M4RKYU.SYS readout. Pass a React node to swap in a custom mark.
+   */
+  markGlyph?: React.ReactNode;
+  /** Version label rendered in the title bar. */
+  versionLabel?: string;
+  className?: string;
+}
+
+const DEFAULT_MARK = `> M4RKYU
+> SYSTEM ONLINE
+> ENGINEER · ARTIST · DEV`;
+
+export function CommandHero({
+  status,
+  markGlyph,
+  versionLabel = "v2027",
+  className,
+}: CommandHeroProps) {
+  return (
+    <BlurFade className={cn("h-full", className)}>
+      <PixelPanel
+        eyebrow="m4rkyu.sys"
+        title={versionLabel}
+        className="relative h-full overflow-hidden"
+      >
+        {/* atmospheric grid substrate, masked to the panel body */}
+        <div
+          aria-hidden="true"
+          className="bg-cyber-grid pointer-events-none absolute inset-0 opacity-20 [mask-image:radial-gradient(circle_at_center,black,transparent_80%)]"
+        />
+        <div className="relative flex min-h-[16rem] flex-col justify-between gap-8 py-4 text-center">
+          <pre
+            aria-hidden="true"
+            className="font-pixel select-none text-base leading-tight text-foreground/85"
+          >
+            {markGlyph ?? DEFAULT_MARK}
+          </pre>
+          {status ? (
+            <div className="flex items-center justify-center gap-3">
+              <SystemBadge kind="now" />
+              {status.href ? (
+                <Link
+                  href={status.href}
+                  aria-label={
+                    status.accessibleLabel ?? `Open ${status.label}`
+                  }
+                  className="font-mono text-xs text-muted-foreground transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:text-foreground"
+                >
+                  {status.label}
+                </Link>
+              ) : (
+                <span className="font-mono text-xs text-muted-foreground">
+                  {status.label}
+                </span>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </PixelPanel>
+    </BlurFade>
+  );
+}

--- a/src/components/sections/game-hud.tsx
+++ b/src/components/sections/game-hud.tsx
@@ -1,0 +1,43 @@
+import { ThemeSwitcher } from "@/components/theme/theme-switcher";
+import { LanguageSwitcher } from "@/components/system/language-switcher";
+import { cn } from "@/lib/utils";
+
+interface GameHudProps {
+  /**
+   * Translated Cmd-K reminder text. Displayed at the right edge of the
+   * HUD strip; consumer-owned so /en and /zh can supply different copy.
+   * The actual Cmd-K trigger lives in the page header — this is a
+   * passive reminder, not an interactive button.
+   */
+  hint: string;
+  className?: string;
+}
+
+/**
+ * Persistent "system status" strip rendered in the homepage hero
+ * footer (and, in a future phase, every page layout). Composes the
+ * existing locale + theme toggles; the sound toggle slot is wired
+ * in Phase 7.
+ */
+export function GameHud({ hint, className }: GameHudProps) {
+  return (
+    <nav
+      aria-label="System status"
+      className={cn(
+        "flex flex-wrap items-center gap-x-4 gap-y-3 border-t border-border/60 pt-4",
+        className,
+      )}
+    >
+      <LanguageSwitcher />
+      <ThemeSwitcher />
+      {/* Phase 7 slot — SoundToggle will land here without disturbing layout. */}
+      {/* `font-mono` (not `font-pixel`) because the zh hint contains the CJK
+        * character "按"; the `:lang(zh)` guard in globals.css doesn't yet
+        * fire (root layout still hardcodes `lang="en"`), so font-pixel
+        * would render that glyph through the per-glyph VT323 fallback. */}
+      <span className="ml-auto font-mono text-xs uppercase tracking-[0.16em] text-muted-foreground">
+        {hint}
+      </span>
+    </nav>
+  );
+}

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -1,185 +1,65 @@
-"use client"
+import { ArrowUpRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { PixelButton } from "@/components/ui/pixel/pixel-button";
+import { Button } from "@/components/ui/button";
+import { CommandHero } from "./command-hero";
+import { GameHud } from "./game-hud";
+import { Link } from "@/i18n/navigation";
+import type { Locale } from "@/i18n/routing";
 
-import { motion } from "motion/react"
-import { useTranslations } from "next-intl"
-import { ArrowRight, Code } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Marquee } from "@/components/ui/marquee"
-import { AnimatedGridPattern } from "@/components/ui/magic/animated-grid-pattern"
-import { PointerSpotlight } from "@/components/ui/magic/pointer-spotlight"
-import { Link } from "@/i18n/navigation"
-import type { Locale } from "@/i18n/routing"
-
-const ease = [0.2, 0.7, 0.2, 1] as const
-
-const marqueeItems = [
-  "Software Engineer",
-  "Frontend Developer",
-  "Game Developer",
-  "Digital Artist",
-  "Next.js",
-  "TypeScript",
-  "React",
-  "Unity",
-  "Tailwind CSS",
-  "Creative Systems",
-  "UI Design",
-  "Web Apps",
-]
-
-const headlineLines = [
-  { text: "Engineer.", dim: false },
-  { text: "Artist.",   dim: true  },
-  { text: "Designer.", dim: false },
-]
-
-const sideItems = [
-  { n: "01", label: "software"   },
-  { n: "02", label: "games"      },
-  { n: "03", label: "art"        },
-  { n: "04", label: "interfaces" },
-]
-
-export function HeroSection({ locale }: { locale: Locale }) {
-  const t = useTranslations("Home")
+export async function HeroSection({ locale }: { locale: Locale }) {
+  const t = await getTranslations({ locale, namespace: "Home" });
 
   return (
     <section className="relative overflow-hidden border-b">
-      {/* atmospheric layers */}
-      <AnimatedGridPattern
-        numSquares={28}
-        maxOpacity={0.18}
-        duration={5}
-        repeatDelay={0.8}
-        className="text-foreground/40"
-      />
+      {/* Atmospheric layers — `noise` + `scanline` carry the 20% cyber
+        * slice from docs/UNIFIED_VISUAL_DIRECTION.md §2; cyber-grid is
+        * scoped to CommandHero so the homepage stays editorial-first. */}
       <div className="noise-layer absolute inset-0" aria-hidden="true" />
-      <div className="scanline-layer absolute inset-0 opacity-35" aria-hidden="true" />
-      <PointerSpotlight radius={420} intensity={0.14} />
+      <div
+        className="scanline-layer absolute inset-0 opacity-25"
+        aria-hidden="true"
+      />
 
-      {/* main grid */}
-      <div className="relative mx-auto grid min-h-[calc(100dvh-4rem-2.75rem)] w-full max-w-7xl items-center gap-10 px-4 py-16 sm:px-6 lg:grid-cols-[1fr_400px] lg:gap-16 lg:px-8">
-
-        {/* ── left ── */}
-        <div>
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4, ease }}
-            className="mb-7 flex flex-wrap items-center gap-2.5"
-          >
-            <span className="font-mono text-[0.68rem] uppercase tracking-[0.32em] text-muted-foreground">
-              ZX Mark Yu
-            </span>
-            <span className="text-muted-foreground/40 font-mono text-[0.68rem]">/</span>
-            <span className="rounded border border-ring/50 px-2 py-0.5 font-mono text-[0.65rem] uppercase tracking-[0.14em] text-ring">
-              2027 Prototype
-            </span>
-          </motion.div>
-
-          <h1 className="text-[3.2rem] font-[800] leading-[0.9] tracking-normal sm:text-7xl lg:text-8xl">
-            {headlineLines.map(({ text, dim }, i) => (
-              <span key={text} className="block overflow-hidden">
-                <motion.span
-                  className={`block ${dim ? "text-muted-foreground/45" : ""}`}
-                  initial={{ y: "105%" }}
-                  animate={{ y: "0%" }}
-                  transition={{ duration: 0.65, delay: 0.12 + i * 0.14, ease }}
-                >
-                  {text}
-                </motion.span>
-              </span>
-            ))}
+      <div className="relative mx-auto grid w-full max-w-7xl items-start gap-10 px-4 py-20 sm:px-6 lg:grid-cols-[1fr_400px] lg:gap-16 lg:py-28 lg:px-8">
+        {/* Left column — eyebrow, headline, subtitle, two CTAs. */}
+        <BlurFade className="flex flex-col gap-7">
+          <span className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+            {t("eyebrow")}
+          </span>
+          <h1 className="font-display text-balance text-[3rem] font-extrabold leading-[0.95] tracking-normal sm:text-6xl lg:text-7xl">
+            {t("title")}
           </h1>
-
-          <motion.p
-            initial={{ opacity: 0, y: 14 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.7, ease }}
-            className="mt-9 max-w-md text-lg leading-8 text-muted-foreground"
-          >
+          <p className="max-w-xl text-lg leading-8 text-muted-foreground">
             {t("subtitle")}
-          </motion.p>
-
-          <motion.div
-            initial={{ opacity: 0, y: 14 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.88, ease }}
-            className="mt-9 flex flex-wrap gap-3"
-          >
-            <Button asChild size="lg">
+          </p>
+          <div className="flex flex-wrap items-center gap-3 pt-2">
+            <PixelButton glyph="caret" sound="confirm" size="lg" asChild>
               <Link href="/projects" locale={locale}>
-                {t("primaryCta")}
-                <ArrowRight className="size-4" />
+                {t("heroCtaBrowse")}
+              </Link>
+            </PixelButton>
+            <Button variant="outline" size="lg" asChild>
+              <Link href="/blog" locale={locale}>
+                {t("heroCtaLogs")}
+                <ArrowUpRight className="size-4" aria-hidden="true" />
               </Link>
             </Button>
-            <Button asChild size="lg" variant="outline">
-              <Link href="/portal" locale={locale}>
-                {t("portalCta")}
-              </Link>
-            </Button>
-            <Button asChild size="lg" variant="ghost">
-              <a href="https://github.com/zhenxiao-yu" target="_blank" rel="noopener noreferrer">
-                <Code className="size-4" />
-                GitHub
-              </a>
-            </Button>
-          </motion.div>
-        </div>
-
-        {/* ── right card ── */}
-        <motion.div
-          initial={{ opacity: 0, x: 36 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.65, delay: 0.18, ease }}
-          className="relative hidden overflow-hidden rounded-xl border bg-card/55 p-6 shadow-2xl backdrop-blur-sm lg:block"
-        >
-          <div className="absolute inset-0 bg-cyber-grid opacity-20" aria-hidden="true" />
-          <div className="relative flex h-full min-h-[26rem] flex-col justify-between gap-6">
-
-            <div className="flex items-center justify-between font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
-              <span>creative systems</span>
-              <span>2027</span>
-            </div>
-
-            <div className="grid gap-2">
-              {sideItems.map(({ n, label }) => (
-                <div key={label} className="grid grid-cols-[2rem_1fr] items-center gap-3">
-                  <span className="font-mono text-[0.6rem] text-muted-foreground/50">{n}</span>
-                  <div className="flex h-11 items-center border bg-background/55 px-4 font-[family-name:var(--font-display)] text-base uppercase tracking-[0.14em] transition-colors duration-200 hover:bg-background/80">
-                    {label}
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-              {["SEO", "i18n", "themes", "a11y"].map((tag) => (
-                <div
-                  key={tag}
-                  className="rounded border bg-background/45 px-2 py-1.5 text-center font-mono text-[0.6rem] uppercase tracking-[0.16em] text-muted-foreground"
-                >
-                  {tag}
-                </div>
-              ))}
-            </div>
-
-            <p className="font-mono text-[0.68rem] leading-5 text-muted-foreground/60">
-              Full-stack creative developer — software, games, and digital art built with precision.
-            </p>
-
           </div>
-        </motion.div>
+        </BlurFade>
+
+        {/* Right column — atmospheric command card. Visible at every
+          * viewport per docs/UNIFIED_VISUAL_DIRECTION.md §9.1; the grid
+          * is single-column below `lg`, so it stacks under the headline
+          * on tablet and mobile rather than disappearing. */}
+        <CommandHero />
       </div>
 
-      {/* marquee strip */}
-      <div className="relative border-t bg-background/30">
-        <Marquee
-          items={marqueeItems}
-          speed="normal"
-          className="py-3 font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground/70"
-        />
+      {/* Footer HUD strip */}
+      <div className="relative mx-auto w-full max-w-7xl px-4 pb-6 sm:px-6 lg:px-8">
+        <GameHud hint={t("heroCmdkHint")} />
       </div>
     </section>
-  )
+  );
 }

--- a/src/components/ui/pixel/pixel-button.stories.tsx
+++ b/src/components/ui/pixel/pixel-button.stories.tsx
@@ -37,3 +37,14 @@ export const Link: Story = {
 export const Disabled: Story = {
   args: { glyph: "caret", disabled: true },
 };
+
+// Covers the asChild + glyph code path used by the homepage hero CTAs —
+// PixelButton clones the consumer's child and injects the glyph so
+// Radix Slot still receives exactly one element.
+export const AsLink: Story = {
+  args: {
+    glyph: "caret",
+    asChild: true,
+    children: <a href="#">Browse the work</a>,
+  },
+};

--- a/src/components/ui/pixel/pixel-button.tsx
+++ b/src/components/ui/pixel/pixel-button.tsx
@@ -11,6 +11,9 @@ const GLYPHS: Record<Glyph, string> = {
   send: "↵",
 };
 
+const GLYPH_CLASS =
+  "font-pixel text-base leading-none opacity-60 transition duration-(--motion-fast) ease-(--ease-premium) group-hover:translate-x-0.5 group-hover:opacity-100";
+
 export interface PixelButtonProps extends ButtonProps {
   /** Optional leading VT323 glyph that slides in on hover. */
   glyph?: Glyph;
@@ -28,28 +31,45 @@ export const PixelButton = React.forwardRef<HTMLButtonElement, PixelButtonProps>
   // attribute. Phase 7 (Web Audio module + SoundToggle) will swap the
   // unused destructure for an `useUiSound(sound)` hook fired on click.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Phase 7 stub
-  ({ glyph, sound, className, children, ...rest }, ref) => {
+  ({ glyph, sound, asChild, className, children, ...rest }, ref) => {
+    const baseClass = cn(
+      // `transition` covers transform AND colors (both in v4's default
+      // property set), so the press scale + the inherited hover-color
+      // animation share one timing function. `active:scale-[0.98]` is
+      // the "confirm" press from §7.2.
+      "group transition duration-(--motion-micro) ease-(--ease-premium) active:scale-[0.98]",
+      className,
+    );
+
+    const glyphNode = glyph ? (
+      <span aria-hidden="true" className={GLYPH_CLASS}>
+        {GLYPHS[glyph]}
+      </span>
+    ) : null;
+
+    // When `asChild` is set, Radix Slot expects exactly one child element
+    // and merges Button's props onto it. Inject the glyph into the
+    // consumer's child so Slot still sees a single element.
+    if (asChild && glyphNode) {
+      const child = React.Children.only(children) as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      const merged = React.cloneElement(
+        child,
+        undefined,
+        glyphNode,
+        child.props.children,
+      );
+      return (
+        <Button ref={ref} asChild className={baseClass} {...rest}>
+          {merged}
+        </Button>
+      );
+    }
+
     return (
-      <Button
-        ref={ref}
-        // `transition` covers transform AND colors (both in v4's default
-        // property set), so the press scale + the inherited hover-color
-        // animation share one timing function. `active:scale-[0.98]` is
-        // the "confirm" press from §7.2.
-        className={cn(
-          "group transition duration-(--motion-micro) ease-(--ease-premium) active:scale-[0.98]",
-          className,
-        )}
-        {...rest}
-      >
-        {glyph ? (
-          <span
-            aria-hidden="true"
-            className="font-pixel text-base leading-none opacity-60 transition duration-(--motion-fast) ease-(--ease-premium) group-hover:translate-x-0.5 group-hover:opacity-100"
-          >
-            {GLYPHS[glyph]}
-          </span>
-        ) : null}
+      <Button ref={ref} asChild={asChild} className={baseClass} {...rest}>
+        {glyphNode}
         {children}
       </Button>
     );

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -32,8 +32,16 @@ test("theme and language controls are visible on desktop", async ({ page }) => {
   if (await menu.isVisible()) {
     await menu.click();
   }
-  await expect(page.locator('[data-testid="language-switcher"]:visible')).toBeVisible();
-  await expect(page.locator('[data-testid="theme-toggle"]:visible')).toBeVisible();
+  // `.first()` because Phase 3 surfaces the same controls in the
+  // hero's GameHud strip as well as the header — both are valid
+  // entry points; the test only needs to confirm at least one is
+  // reachable. Mirrors the `.first()` pattern used on line 45.
+  await expect(
+    page.locator('[data-testid="language-switcher"]:visible').first(),
+  ).toBeVisible();
+  await expect(
+    page.locator('[data-testid="theme-toggle"]:visible').first(),
+  ).toBeVisible();
 });
 
 test("theme toggle flips data-theme on click", async ({ page }) => {


### PR DESCRIPTION
## Summary

Phase 3 of [docs/UNIFIED_VISUAL_DIRECTION.md](docs/UNIFIED_VISUAL_DIRECTION.md) — rebuilds the homepage hero around the Phase-2 primitives, introduces `CommandHero` (right-column terminal card) and `GameHud` (bottom status strip), and ships new bilingual hero copy. The rest of the homepage is intentionally untouched.

- **[HeroSection](src/components/sections/hero-section.tsx)** — full rewrite as an async server component. Reads the new keys via `getTranslations`. The prior 3-line layered headline (\"Engineer. Artist. Designer.\"), numbered side card, GitHub CTA, and mono marquee strip are retired (per your earlier clarification).
- **[CommandHero](src/components/sections/command-hero.tsx)** *(new)* — `PixelPanel`-framed card with a masked `bg-cyber-grid` substrate and a default VT323 ASCII brand mark. Optional `status` slot is wired but unused in this PR — a follow-up will surface the latest shipping project there.
- **[GameHud](src/components/sections/game-hud.tsx)** *(new)* — persistent `<nav aria-label=\"System status\">` composing the existing `LanguageSwitcher` + `ThemeSwitcher` + a translated Cmd-K hint. Phase-7 sound toggle slot is documented in code, not yet rendered.

### Content picks (per your clarification)
- **Headline option 2**: \"One archive. Software, art, games.\" / 一份档案。软件、艺术、游戏。
- **Matching subtitle 2** (EN + hand-written ZH).
- **Marquee retired**.

### PixelButton enhancement (Phase-2 follow-on)
[pixel-button.tsx](src/components/ui/pixel/pixel-button.tsx) gained an `asChild + glyph` composition path: when both are passed, it clones the consumer's child via `React.cloneElement` and injects the glyph as the first child so Radix Slot still receives a single element. The hero's primary CTA needs this (`<PixelButton glyph=\"caret\" asChild><Link>…</Link></PixelButton>`). New `AsLink` story locks the path in.

## Translation parity

`messages/en.json` and `messages/zh.json` each gained three keys (`heroCtaBrowse`, `heroCtaLogs`, `heroCmdkHint`) and saw three repurposed in-place (`eyebrow`, `title`, `subtitle`). Pre-existing keys (`primaryCta`, `portalCta`, …) are untouched — the closing CTA strip on the same page still uses `primaryCta`, so I left it alone.

## Test adjustment

[tests/smoke.spec.ts:35-36](tests/smoke.spec.ts#L35-L36) gained `.first()` on both `language-switcher` / `theme-toggle` lookups, matching the existing `.first()` idiom on line 45. Phase 3 surfaces those controls in both the header and the hero's GameHud, which tripped Playwright strict mode with two visible matches.

## Validation results

- ✅ `npm run validate` — silent.
- ✅ `npm run build-storybook` — clean (5.22s).
- ✅ `npm run test:e2e` — **96 / 96 passed** across 360 / 390 / 768 / 1280 / 1920 + Chromium, including the relaxed visibility check and CommandHero rendering at tablet + mobile.

## Code-reviewer pass

**0 BLOCK / 2 SHOULD-FIX (both applied) / 4 NIT.** Applied:

- **GameHud hint** uses `font-mono` (not `font-pixel`) — the zh hint contains \"按\". The `:lang(zh)` guard from Phase 1 doesn't yet fire because [src/app/layout.tsx](src/app/layout.tsx) hardcodes `lang=\"en\"` and the locale layout doesn't propagate `lang={locale}`. Future PR can wire that and restore `font-pixel`.
- **CommandHero now renders at every viewport** (stacks under the headline below `lg`), matching [§9.1](docs/UNIFIED_VISUAL_DIRECTION.md) tablet + mobile spec. The prior `hidden lg:block` would have dropped the tablet experience entirely.

NITs acknowledged: status `aria-label` defaults to English (`Open ${label}`) — only matters if a future caller passes `status` without an `accessibleLabel`; `React.Children.only` error message is React's generic one (sufficient); 360px headline wrap is covered by smoke; smoke comment is sufficient.

## Follow-ups flagged

- [src/components/ui/marquee.tsx](src/components/ui/marquee.tsx) is now unused — a future cleanup PR can remove it.
- Propagating `lang={locale}` to the DOM (so the Phase-1 `:lang(zh)` CJK guard fires) would let GameHud's hint return to `font-pixel`.

## Test plan

- [x] `npm run validate` silent.
- [x] `npm run build-storybook` passes; new `AsLink` story renders.
- [x] `npm run test:e2e` passes the full route matrix.
- [x] No new dependencies; no `next.config.ts` / `tsconfig.json` / `package.json` changes.
- [x] Rest of the homepage untouched — only the hero block within [src/app/[locale]/page.tsx](src/app/[locale]/page.tsx) renders new content.
- [x] EN / ZH key parity verified.
- [ ] *Follow-up*: status pulse data wiring on CommandHero + lang attribute propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)