### PR TITLE
feat(home): numbered capability section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,31 @@
     "heroCtaBrowse": "Browse the work",
     "heroCtaLogs": "Read the logs",
     "heroCmdkHint": ">_ press ⌘K",
+    "capabilities": {
+      "eyebrow": "05 / capabilities",
+      "title": "Systems & surfaces",
+      "lede": "Five overlapping systems, one operator. Each is a real practice, not a buzzword.",
+      "production": {
+        "title": "Production engineering",
+        "description": "Shipping Next.js / TypeScript / CI / observability work — the slow, careful kind that survives the second year."
+      },
+      "interface": {
+        "title": "Interface systems",
+        "description": "Design systems, tokens, motion, Storybook, accessibility — interfaces you can read end-to-end."
+      },
+      "game": {
+        "title": "Game feel & interaction",
+        "description": "Prototypes, input systems, tuning. LAST KERNEL and a small workshop of interactive ideas."
+      },
+      "ai": {
+        "title": "AI-assisted creative tools",
+        "description": "Agent workflows, content pipelines, internal tooling. Models treated as craft, not as a brand."
+      },
+      "visual": {
+        "title": "Visual storytelling",
+        "description": "Photography, film, art direction, gallery curation — frames that earn their place."
+      }
+    },
     "primaryCta": "View projects",
     "portalCta": "Enter portal",
     "featured": "Featured case studies",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -31,6 +31,31 @@
     "heroCtaBrowse": "浏览作品",
     "heroCtaLogs": "阅读日志",
     "heroCmdkHint": ">_ 按 ⌘K",
+    "capabilities": {
+      "eyebrow": "05 / 能力",
+      "title": "系统与界面",
+      "lede": "五个相互重叠的系统，由同一个人操作。每一项都是真实的实践，不是流行语。",
+      "production": {
+        "title": "生产工程",
+        "description": "Next.js / TypeScript / CI / 可观测性 —— 缓慢、谨慎、能在第二年仍然站得住的那种代码。"
+      },
+      "interface": {
+        "title": "界面系统",
+        "description": "设计系统、Token、动效、Storybook、可访问性 —— 可以从头读到尾的界面。"
+      },
+      "game": {
+        "title": "游戏感与交互",
+        "description": "原型、输入系统、手感调校。LAST KERNEL 与一座小型互动想法的工作间。"
+      },
+      "ai": {
+        "title": "AI 辅助创作工具",
+        "description": "Agent 工作流、内容流水线、内部工具。把模型当作手艺，不当作品牌。"
+      },
+      "visual": {
+        "title": "视觉叙事",
+        "description": "摄影、影像、艺术指导、影像档案策展 —— 每一帧都值得留下。"
+      }
+    },
     "primaryCta": "查看项目",
     "portalCta": "进入 Portal",
     "featured": "精选案例",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { HeroSection } from "@/components/sections/hero-section";
+import { CapabilitiesSection } from "@/components/sections/capabilities-section";
 import { IntroLoader } from "@/components/system/intro-loader";
 import { SectionHeading } from "@/components/sections/section-heading";
 import { ProjectCard } from "@/components/cards/project-card";
@@ -100,6 +101,9 @@ export default async function HomePage({
     <PageShell locale={locale}>
       <IntroLoader />
       <HeroSection locale={locale} />
+
+      {/* Numbered capability spine — five overlapping systems (§3.B). */}
+      <CapabilitiesSection locale={locale} />
 
       {/* Status pulse — what's shipping / writing / next */}
       {statusEntries.length > 0 ? (

--- a/src/components/sections/capabilities-section.tsx
+++ b/src/components/sections/capabilities-section.tsx
@@ -1,0 +1,71 @@
+import { getTranslations } from "next-intl/server";
+import { SectionFrame } from "@/components/ui/pixel/section-frame";
+import { NumberedCapability } from "@/components/ui/pixel/numbered-capability";
+import type { Locale } from "@/i18n/routing";
+
+// Capability rows — structural metadata. Titles + descriptions come from
+// the translation file; tags stay canonical English because the values
+// are technology / discipline labels that read the same across locales.
+const CAPABILITY_ROWS = [
+  {
+    id: "production",
+    index: "01",
+    tags: ["Next.js", "TypeScript", "CI", "Observability"],
+  },
+  {
+    id: "interface",
+    index: "02",
+    tags: ["Tailwind", "Tokens", "Motion", "a11y"],
+  },
+  {
+    id: "game",
+    index: "03",
+    tags: ["Unity", "Input", "Tuning", "Prototype"],
+  },
+  {
+    id: "ai",
+    index: "04",
+    tags: ["Agents", "Pipelines", "MDX", "Tooling"],
+  },
+  {
+    id: "visual",
+    index: "05",
+    tags: ["Photo", "Film", "Direction", "Curation"],
+  },
+] as const;
+
+export async function CapabilitiesSection({ locale }: { locale: Locale }) {
+  const t = await getTranslations({
+    locale,
+    namespace: "Home.capabilities",
+  });
+
+  return (
+    <section className="border-b">
+      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 lg:px-8 lg:py-24">
+        {/* No `index` prop — the doc's "05 / capabilities" mono prefix
+          * already lives inside the eyebrow string, so passing both would
+          * paint "05" twice on the same line. */}
+        <SectionFrame
+          eyebrow={t("eyebrow")}
+          title={t("title")}
+          lede={t("lede")}
+        />
+        {/* `divide-y divide-dashed` paints the dotted rule between rows
+          * (NumberedCapability §4.3 visual spec) without each row needing
+          * its own divider logic. */}
+        <div className="mt-10 divide-y divide-dashed divide-border/60">
+          {CAPABILITY_ROWS.map((row) => (
+            <NumberedCapability
+              key={row.id}
+              index={row.index}
+              title={t(`${row.id}.title`)}
+              description={t(`${row.id}.description`)}
+              tags={row.tags}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/pixel/numbered-capability.stories.tsx
+++ b/src/components/ui/pixel/numbered-capability.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NumberedCapability } from "./numbered-capability";
+
+const meta = {
+  title: "ui/pixel/NumberedCapability",
+  component: NumberedCapability,
+  args: {
+    index: "01",
+    title: "Production engineering",
+    description:
+      "Shipping Next.js / TypeScript / CI / observability work — the slow, careful kind that survives the second year.",
+  },
+} satisfies Meta<typeof NumberedCapability>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithTags: Story = {
+  args: {
+    tags: ["Next.js", "TypeScript", "CI", "Observability"],
+  },
+};
+
+export const WithCta: Story = {
+  args: {
+    tags: ["Next.js", "TypeScript", "CI"],
+    cta: { label: "Browse production work", href: "/projects" },
+  },
+};
+
+export const WithVisual: Story = {
+  args: {
+    tags: ["Tailwind", "Tokens", "Motion"],
+    visual: (
+      <div className="aspect-[4/3] w-full rounded-sm border border-border bg-card placeholder-noise" />
+    ),
+  },
+};
+
+// Verifies the row renders cleanly with hand-written Chinese copy.
+// `font-pixel` on the index is allowed because the index is ASCII
+// digits — the :lang(zh) guard from Phase 1 only matters once
+// font-pixel meets translated content.
+export const ZhLocale: Story = {
+  args: {
+    index: "05",
+    title: "视觉叙事",
+    description:
+      "摄影、影像、艺术指导、影像档案策展 —— 每一帧都值得留下。",
+    tags: ["Photo", "Film", "Direction", "Curation"],
+  },
+};

--- a/src/components/ui/pixel/numbered-capability.tsx
+++ b/src/components/ui/pixel/numbered-capability.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+
+interface NumberedCapabilityProps {
+  /** Mono numerical index (e.g. "01"). Rendered in VT323, decorative. */
+  index: string;
+  /** Capability headline — rendered as <h3> in the document outline. */
+  title: string;
+  /** 1–2 sentence body description in Geist. */
+  description: string;
+  /** Optional tech / discipline tag chips. Stays canonical English across locales. */
+  tags?: readonly string[];
+  /** Optional link target. When present, the title becomes the link surface. */
+  cta?: { label: string; href: string };
+  /** Optional small visual rendered in the right slot at md+. */
+  visual?: React.ReactNode;
+  className?: string;
+}
+
+export function NumberedCapability({
+  index,
+  title,
+  description,
+  tags,
+  cta,
+  visual,
+  className,
+}: NumberedCapabilityProps) {
+  // Always render the title inside an `<h3>` so the document outline
+  // stays well-formed regardless of whether a CTA is supplied. The
+  // <Link> nests inside the h3 when `cta` is present.
+  const titleNode = (
+    <h3 className="font-display text-2xl font-extrabold leading-tight sm:text-3xl">
+      {cta ? (
+        <Link
+          href={cta.href}
+          aria-label={cta.label}
+          className="group/cta relative inline-block w-fit text-foreground transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:text-foreground/85"
+        >
+          <span>{title}</span>
+          {/* Underline-from-left reveal — `scale-x` on transform keeps the
+            * animation inside the default `transition` property set so no
+            * arbitrary `transition-[width]` syntax is needed. */}
+          <span
+            aria-hidden="true"
+            className="block h-px origin-left scale-x-0 bg-foreground transition duration-(--motion-fast) ease-(--ease-premium) group-hover/cta:scale-x-100"
+          />
+        </Link>
+      ) : (
+        title
+      )}
+    </h3>
+  );
+
+  return (
+    <BlurFade>
+      <article
+        className={cn(
+          "grid grid-cols-1 gap-4 py-10 md:grid-cols-[5rem_1fr_auto] md:gap-10 md:py-12",
+          className,
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="font-pixel text-2xl leading-none text-muted-foreground md:pt-2 md:text-3xl"
+        >
+          {index}
+        </span>
+        <div className="flex flex-col gap-3">
+          {titleNode}
+          <p className="max-w-prose text-base leading-7 text-muted-foreground">
+            {description}
+          </p>
+          {tags && tags.length > 0 ? (
+            <ul className="flex flex-wrap gap-1.5 pt-1">
+              {tags.map((tag) => (
+                <li
+                  key={tag}
+                  className="rounded-sm border border-border bg-card px-2 py-0.5 font-mono text-[0.65rem] uppercase tracking-[0.16em] text-muted-foreground"
+                >
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        {visual ? (
+          <div className="self-start md:max-w-[18rem]">{visual}</div>
+        ) : null}
+      </article>
+    </BlurFade>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 4 of [docs/UNIFIED_VISUAL_DIRECTION.md](docs/UNIFIED_VISUAL_DIRECTION.md) (§3.B + §4.3) — adds the Lambda-style numbered capability spine to the homepage. One new primitive, one new section composition, three-line page insertion, and bilingual copy for five capability rows.

- **[NumberedCapability](src/components/ui/pixel/numbered-capability.tsx)** *(new)* — Lambda-style numbered row primitive. VT323 mono `index`, Syne `<h3>` `title`, Geist body `description`, optional readonly `tags` chip array, optional `cta`, optional `visual` slot. Hover underline uses `scale-x` + `transition` (default property set) — no `transition-[width]` arbitrary syntax. `group/cta` named-group scopes the underline to the link only, so sibling rows don't trigger each other.
- **[CapabilitiesSection](src/components/sections/capabilities-section.tsx)** *(new)* — async server composition that reads `Home.capabilities.*` via `getTranslations` and renders five rows separated by `divide-y divide-dashed divide-border/60`.
- **[page.tsx](src/app/[locale]/page.tsx)** — single insertion (`<CapabilitiesSection locale={locale} />`) between `<HeroSection>` and `<StatusPulseRow>`. The rest of the homepage is unchanged.
- **[messages/en.json](messages/en.json)** + **[messages/zh.json](messages/zh.json)** — added `Home.capabilities` with `eyebrow` / `title` / `lede` + five `{id}.{title, description}` blocks (production, interface, game, ai, visual). Tags stay canonical English in code (`\"Next.js\"`, `\"Unity\"`, `\"Tailwind\"`) — those read the same across locales.

## Capability rows

| Index | EN | ZH |
| --- | --- | --- |
| 01 | Production engineering | 生产工程 |
| 02 | Interface systems | 界面系统 |
| 03 | Game feel & interaction | 游戏感与交互 |
| 04 | AI-assisted creative tools | AI 辅助创作工具 |
| 05 | Visual storytelling | 视觉叙事 |

## Validation results

- ✅ `npm run validate` — silent.
- ✅ `npm run build-storybook` — clean.
- ✅ `npm run test:e2e` — **96 / 96 passed** across the full viewport matrix.

## Code-reviewer pass

**0 BLOCK / 2 SHOULD-FIX (both applied) / 4 NIT.** Applied:

- **Heading outline preserved.** Title now always renders inside `<h3>`; when `cta` is present, the `<Link>` nests *inside* the h3 (not replacing it). The `WithCta` Storybook story would otherwise have rendered five capability rows with no h3 — silent outline regression. Fix-in-primitive instead of fix-at-call-site.
- **Dropped duplicate \"05\".** The `SectionFrame` call lost its `index=\"05\"` prop because the eyebrow string already starts with `\"05 /\"`. The two would have painted \"05\" twice on the same line.

NIT applied: zh lede `关键词` → `流行语` (closer to \"buzzword\" intent).

NITs acknowledged without code change:
- `readonly` tuple variance into `tags?: readonly string[]` flows cleanly — no TS issues.
- Index glyphs are ASCII (`\"01\"`–`\"05\"`) so VT323 renders natively on `/zh` even with the Phase-1 CJK guard inert.
- Three consecutive `border-b` rules (Hero / Capabilities / StatusPulseRow parent) collapse visually to a single 1px rule via the shared `border-color: var(--border)` from `globals.css`.

## Test plan

- [x] `npm run validate` silent.
- [x] `npm run build-storybook` passes; five new stories (Default, WithTags, WithCta, WithVisual, ZhLocale) render.
- [x] `npm run test:e2e` passes the full viewport matrix.
- [x] No new dependencies; no `next.config.ts` / `tsconfig.json` / `package.json` changes.
- [x] Existing homepage sections untouched.
- [x] EN / ZH key parity verified.
- [ ] *Visual follow-up*: capability `visual` slot is wired but unused on the homepage — Phase 8 polish can add small ASCII / silkscreen visuals if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)