### PR TITLE
feat(projects): mission-module + cartridge

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,14 +4,13 @@ import { HeroSection } from "@/components/sections/hero-section";
 import { CapabilitiesSection } from "@/components/sections/capabilities-section";
 import { IntroLoader } from "@/components/system/intro-loader";
 import { SectionHeading } from "@/components/sections/section-heading";
-import { ProjectCard } from "@/components/cards/project-card";
+import { MissionModuleCard } from "@/components/ui/pixel/mission-module-card";
+import { ArchiveTile } from "@/components/ui/pixel/archive-tile";
 import { ArchiveCard } from "@/components/cards/archive-card";
 import { ResourcePreviewCard } from "@/components/cards/resource-preview-card";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { BentoGrid } from "@/components/ui/magic/bento-grid";
-import { GalleryBentoTile } from "@/components/gallery/gallery-bento-tile";
 import { PageShell } from "@/components/layout/page-shell";
 import { PlaceholderVideo } from "@/components/placeholders/placeholder-video";
 import { FadeIn } from "@/components/motion/fade-in";
@@ -131,7 +130,7 @@ export default async function HomePage({
         </div>
         <div className="mt-10 grid gap-5 md:grid-cols-3">
           {featuredProjects.slice(0, 3).map((project, index) => (
-            <ProjectCard
+            <MissionModuleCard
               key={project.slug}
               project={project}
               locale={locale}
@@ -200,15 +199,15 @@ export default async function HomePage({
           </FadeIn>
           <FadeIn direction="left" delay={0.1}>
             {bentoFrames ? (
-              <BentoGrid className="lg:auto-rows-[12rem] lg:grid-cols-2">
+              <div className="grid gap-3 sm:grid-cols-2 lg:gap-4">
                 {bentoFrames.map((item, index) => (
-                  <GalleryBentoTile
+                  <ArchiveTile
                     key={item.slug}
                     item={item}
-                    span={index === 0 ? "sm:row-span-2" : undefined}
+                    aspect={index === 0 ? "4/5" : "1/1"}
                   />
                 ))}
-              </BentoGrid>
+              </div>
             ) : (
               <div className="grid gap-4 sm:grid-cols-2">
                 {galleryCollections.slice(0, 2).map((collection) => (

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { PageShell } from "@/components/layout/page-shell";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
 import { BlurFade } from "@/components/ui/magic/blur-fade";
-import { CaseStudyHeader } from "@/components/case-study/case-study-header";
+import { ProjectCartridge } from "@/components/ui/pixel/project-cartridge";
 import {
   CaseStudyList,
   CaseStudySection,
@@ -94,8 +94,9 @@ export default async function ProjectDetailPage({
   return (
     <PageShell locale={locale}>
       <article>
-        <CaseStudyHeader
+        <ProjectCartridge
           project={project}
+          locale={locale}
           title={localized.title}
           shortPitch={localized.shortPitch as string}
           role={localized.role as string}

--- a/src/components/ui/pixel/archive-tile.stories.tsx
+++ b/src/components/ui/pixel/archive-tile.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ArchiveTile } from "./archive-tile";
+import { galleryItems } from "@/content/gallery";
+
+const sample = galleryItems[0];
+
+const meta = {
+  title: "ui/pixel/ArchiveTile",
+  component: ArchiveTile,
+  args: {
+    item: sample,
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-xs">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ArchiveTile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Square: Story = { args: { aspect: "1/1" } };
+export const Wide: Story = { args: { aspect: "3/2" } };
+export const Cinematic: Story = { args: { aspect: "16/9" } };
+
+// Tile with no `src` — exercises the cyber-grid loading background +
+// PlaceholderImage fallback. Same path used for `coming-soon` frames.
+export const NoCover: Story = {
+  args: {
+    item: { ...sample, src: undefined },
+  },
+};

--- a/src/components/ui/pixel/archive-tile.tsx
+++ b/src/components/ui/pixel/archive-tile.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+import type { GalleryItem } from "@/content/schemas";
+
+type Aspect = "1/1" | "3/2" | "4/5" | "16/9";
+
+const ASPECT_CLASS: Record<Aspect, string> = {
+  "1/1": "aspect-square",
+  "3/2": "aspect-[3/2]",
+  "4/5": "aspect-[4/5]",
+  "16/9": "aspect-video",
+};
+
+interface ArchiveTileProps {
+  item: GalleryItem;
+  /** Frame aspect ratio. Defaults to 4/5 (vertical photographic). */
+  aspect?: Aspect;
+  className?: string;
+}
+
+/**
+ * Contact-sheet tile used in the homepage Creative Archive section
+ * (Phase 5) and on /gallery in a later phase. The whole tile is a
+ * deep-link into the lightbox via `?frame=<slug>`; image grayscales on
+ * rest, regains color on hover. `bg-cyber-grid` shows through while
+ * the image is loading so empty cells still feel intentional.
+ */
+export function ArchiveTile({
+  item,
+  aspect = "4/5",
+  className,
+}: ArchiveTileProps) {
+  const t = useTranslations("Gallery");
+  return (
+    <BlurFade className={cn(className)}>
+      <Link
+        href={`/gallery?frame=${item.slug}`}
+        aria-label={t("openFrame", { title: item.title })}
+        className="group block overflow-hidden rounded-sm border border-border bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <div
+          className={cn(
+            "relative overflow-hidden bg-cyber-grid",
+            ASPECT_CLASS[aspect],
+          )}
+        >
+          {item.src ? (
+            <Image
+              src={item.src.src}
+              alt={item.src.alt}
+              fill
+              sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw"
+              className="object-cover grayscale transition duration-(--motion-slow) ease-(--ease-premium) group-hover:scale-[1.02] group-hover:grayscale-0"
+            />
+          ) : (
+            <PlaceholderImage
+              label={t("frameTbd")}
+              aspect="h-full"
+              className="rounded-none border-0"
+            />
+          )}
+        </div>
+        {/* Spine chip — collection slug on the left, frame type on the right. */}
+        <div className="flex items-center justify-between gap-2 border-t border-border/60 bg-card/90 px-3 py-2">
+          <span className="line-clamp-1 font-mono text-[0.65rem] uppercase tracking-[0.16em] text-muted-foreground">
+            {item.collection}
+          </span>
+          <Badge variant="outline" className="shrink-0 font-mono text-[0.6rem]">
+            {item.type}
+          </Badge>
+        </div>
+      </Link>
+    </BlurFade>
+  );
+}

--- a/src/components/ui/pixel/mission-module-card.stories.tsx
+++ b/src/components/ui/pixel/mission-module-card.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { MissionModuleCard } from "./mission-module-card";
+import { allProjects } from "@/content/projects";
+
+const sample = allProjects[0];
+
+const meta = {
+  title: "ui/pixel/MissionModuleCard",
+  component: MissionModuleCard,
+  args: {
+    project: sample,
+    locale: "en",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MissionModuleCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Highlighted: Story = {
+  args: { highlighted: true },
+};
+
+export const Compact: Story = {
+  args: { compact: true },
+};
+
+export const ZhLocale: Story = {
+  args: { locale: "zh" },
+};

--- a/src/components/ui/pixel/mission-module-card.tsx
+++ b/src/components/ui/pixel/mission-module-card.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import Image from "next/image";
+import { ArrowUpRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { SystemBadge } from "./system-badge";
+import { BorderBeam } from "@/components/ui/magic/border-beam";
+import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
+import { Link } from "@/i18n/navigation";
+import { localize } from "@/lib/content/localize";
+import { cn } from "@/lib/utils";
+import type { Locale } from "@/i18n/routing";
+import type { Project } from "@/content/schemas";
+
+interface MissionModuleCardProps {
+  project: Project;
+  locale: Locale;
+  /**
+   * Wraps the card with a BorderBeam highlight. Use sparingly — no more
+   * than one beam in view at once per docs/UI_LIBRARY_STRATEGY.md §9.
+   */
+  highlighted?: boolean;
+  /** Drops the pitch paragraph for tighter list layouts. */
+  compact?: boolean;
+}
+
+// Cartridge corner notch (top-right). `sm:` only — hidden below `sm` to
+// avoid awkward clipping when the card collapses to full width.
+const NOTCH_CLASS =
+  "sm:[clip-path:polygon(0_0,calc(100%-14px)_0,100%_14px,100%_100%,0_100%)]";
+
+export function MissionModuleCard({
+  project,
+  locale,
+  highlighted = false,
+  compact = false,
+}: MissionModuleCardProps) {
+  const localized = localize(project, locale);
+  const cover = project.screenshots[0];
+  const stackDisplay =
+    project.stack.length > 5
+      ? [...project.stack.slice(0, 4), `+${project.stack.length - 4}`]
+      : project.stack;
+
+  return (
+    <div className="relative h-full">
+      {highlighted ? <BorderBeam duration={14} borderRadius={8} /> : null}
+      <Link
+        href={`/projects/${project.slug}`}
+        locale={locale}
+        aria-label={localized.title as string}
+        className="group block h-full rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <Card
+          className={cn(
+            "relative h-full overflow-hidden bg-card/80 transition duration-(--motion-medium) ease-(--ease-premium) group-hover:-translate-y-1 group-hover:border-ring/40 group-hover:shadow-lg group-hover:shadow-ring/5",
+            NOTCH_CLASS,
+          )}
+        >
+          {/* Cartridge spine — 4px top bar that brightens on hover. */}
+          <div
+            aria-hidden="true"
+            className="absolute inset-x-0 top-0 h-1 bg-muted transition-colors duration-(--motion-fast) ease-(--ease-premium) group-hover:bg-ring/60"
+          />
+          <div className="relative aspect-16/10 overflow-hidden border-b bg-muted">
+            {cover ? (
+              <Image
+                src={cover.src}
+                alt={cover.alt}
+                fill
+                sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 100vw"
+                className="object-cover grayscale transition duration-500 group-hover:scale-[1.03] group-hover:grayscale-0"
+              />
+            ) : (
+              <PlaceholderImage
+                label="PROJECT MEDIA TBD"
+                aspect="h-full"
+                className="rounded-none border-0"
+              />
+            )}
+          </div>
+          <div className="flex flex-col gap-3 p-5">
+            <div className="flex items-center justify-between gap-3">
+              <SystemBadge status={project.contentStatus} />
+              <span className="font-mono text-xs text-muted-foreground">
+                {project.year}
+              </span>
+            </div>
+            <h3 className="text-base font-semibold leading-snug text-foreground">
+              <span className="inline-flex items-baseline gap-1">
+                {localized.title as string}
+                <ArrowUpRight
+                  aria-hidden="true"
+                  className="size-3.5 self-center opacity-50 transition duration-(--motion-fast) ease-(--ease-premium) group-hover:translate-x-0.5 group-hover:opacity-100"
+                />
+              </span>
+            </h3>
+            {compact ? null : (
+              <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">
+                {localized.shortPitch as string}
+              </p>
+            )}
+            <ul className="flex flex-wrap gap-1.5 pt-1">
+              {stackDisplay.map((item) => (
+                <li key={item}>
+                  <Badge variant="outline" className="text-[0.65rem]">
+                    {item}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Card>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/ui/pixel/project-cartridge.stories.tsx
+++ b/src/components/ui/pixel/project-cartridge.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ProjectCartridge } from "./project-cartridge";
+import { allProjects } from "@/content/projects";
+import { localize } from "@/lib/content/localize";
+
+const sample = allProjects[0];
+const localized = localize(sample, "en");
+
+const meta = {
+  title: "ui/pixel/ProjectCartridge",
+  component: ProjectCartridge,
+  args: {
+    project: sample,
+    locale: "en",
+    title: localized.title as string,
+    shortPitch: localized.shortPitch as string,
+    role: localized.role as string,
+  },
+} satisfies Meta<typeof ProjectCartridge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Featured: Story = {
+  args: {
+    project: { ...sample, featured: true },
+  },
+};
+
+export const Draft: Story = {
+  args: {
+    project: { ...sample, contentStatus: "draft" },
+  },
+};
+
+export const ZhLocale: Story = {
+  args: (() => {
+    const zhLocalized = localize(sample, "zh");
+    return {
+      locale: "zh",
+      title: zhLocalized.title as string,
+      shortPitch: zhLocalized.shortPitch as string,
+      role: zhLocalized.role as string,
+    };
+  })(),
+};

--- a/src/components/ui/pixel/project-cartridge.tsx
+++ b/src/components/ui/pixel/project-cartridge.tsx
@@ -1,0 +1,150 @@
+import { ArrowUpRight } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BlurFade } from "@/components/ui/magic/blur-fade";
+import { BorderBeam } from "@/components/ui/magic/border-beam";
+import { PixelPanel } from "./pixel-panel";
+import { SystemBadge } from "./system-badge";
+import { Link } from "@/i18n/navigation";
+import type { Locale } from "@/i18n/routing";
+import type { Project } from "@/content/schemas";
+
+interface ProjectCartridgeProps {
+  project: Project;
+  locale: Locale;
+  /** Localized project title — comes from `localize(project, locale).title`. */
+  title: string;
+  /** Localized short pitch — single line below the title. */
+  shortPitch: string;
+  /** Localized role description for the metadata `<dl>`. */
+  role: string;
+}
+
+/**
+ * Detail-page header card. Replaces CaseStudyHeader on /projects/[slug].
+ * Featured projects get a single BorderBeam treatment around the
+ * cartridge label per docs/UI_LIBRARY_STRATEGY.md §5 (one beam per page).
+ */
+export async function ProjectCartridge({
+  project,
+  locale,
+  title,
+  shortPitch,
+  role,
+}: ProjectCartridgeProps) {
+  const t = await getTranslations({ locale, namespace: "CaseStudy" });
+  const tProjects = await getTranslations({ locale, namespace: "Projects" });
+  const tCategories = await getTranslations({
+    locale,
+    namespace: "Categories",
+  });
+
+  return (
+    <header className="relative overflow-hidden border-b">
+      {/* atmospheric layers — keep parity with the prior CaseStudyHeader */}
+      <div
+        className="absolute inset-0 bg-cyber-grid opacity-30"
+        aria-hidden="true"
+      />
+      <div className="archive-vignette absolute inset-0" aria-hidden="true" />
+
+      <div className="relative mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <Link
+          href="/projects"
+          locale={locale}
+          className="font-mono text-[0.7rem] uppercase tracking-[0.24em] text-muted-foreground transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:text-foreground"
+        >
+          ← {t("projectsIndex")}
+        </Link>
+
+        <BlurFade className="mt-10 flex flex-col gap-7">
+          {/* Cartridge label — inset PixelPanel hosting category / year /
+            * status. Featured projects gain a BorderBeam around it. */}
+          <aside className="relative max-w-md">
+            {project.featured ? (
+              <BorderBeam duration={14} borderRadius={6} />
+            ) : null}
+            <PixelPanel>
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                  {tCategories(project.category)} · {project.year}
+                </span>
+                {/* SystemBadge already shows the contentStatus with a
+                  * friendly localized-ish label (Ready / Draft / Pending /
+                  * Soon); a second DraftBadge would duplicate the chip
+                  * and leak the raw enum value into the UI. */}
+                <SystemBadge status={project.contentStatus} />
+              </div>
+            </PixelPanel>
+          </aside>
+
+          <h1 className="max-w-5xl text-balance font-display text-[clamp(2.5rem,6vw,5.5rem)] font-bold leading-[0.95] tracking-tight">
+            {title}
+          </h1>
+
+          <p className="max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
+            {shortPitch}
+          </p>
+
+          {/* Metadata dl — role / stack / links. On mobile, actions scroll
+            * horizontally per §4.11. The `dl` rows are auto-stacking. */}
+          <dl className="mt-6 grid gap-6 border-t pt-6 sm:grid-cols-[auto_1fr] sm:gap-x-10">
+            <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+              {tProjects("role")}
+            </dt>
+            <dd className="text-sm leading-7 text-foreground">{role}</dd>
+
+            <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+              {tProjects("stack")}
+            </dt>
+            <dd className="flex flex-wrap gap-1.5">
+              {project.stack.map((item) => (
+                <Badge
+                  key={item}
+                  variant="outline"
+                  className="text-[0.65rem]"
+                >
+                  {item}
+                </Badge>
+              ))}
+            </dd>
+
+            {project.liveUrl || project.githubUrl ? (
+              <>
+                <dt className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+                  {t("links")}
+                </dt>
+                <dd className="-mx-1 flex flex-nowrap gap-2 overflow-x-auto px-1 sm:flex-wrap sm:overflow-visible">
+                  {project.liveUrl ? (
+                    <Button asChild size="sm">
+                      <a
+                        href={project.liveUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {tProjects("live")}
+                        <ArrowUpRight aria-hidden="true" className="size-3.5" />
+                      </a>
+                    </Button>
+                  ) : null}
+                  {project.githubUrl ? (
+                    <Button asChild size="sm" variant="outline">
+                      <a
+                        href={project.githubUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {tProjects("source")}
+                      </a>
+                    </Button>
+                  ) : null}
+                </dd>
+              </>
+            ) : null}
+          </dl>
+        </BlurFade>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 5 of [docs/UNIFIED_VISUAL_DIRECTION.md](docs/UNIFIED_VISUAL_DIRECTION.md) — three new pixel primitives + three surgical migrations. The previous components ([ProjectCard](src/components/cards/project-card.tsx), [CaseStudyHeader](src/components/case-study/case-study-header.tsx), [GalleryBentoTile](src/components/gallery/gallery-bento-tile.tsx)) remain in service on routes outside this phase's scope — `/projects` archive list, `/games/[slug]` detail header, `/gallery` index.

### New primitives

| Primitive | Use site | Component shape |
| --- | --- | --- |
| **[MissionModuleCard](src/components/ui/pixel/mission-module-card.tsx)** | Homepage featured row | Server. Whole card = `<Link>`. Cartridge spine + corner notch + grayscale cover + `SystemBadge(contentStatus)` + truncated stack chips. `BorderBeam` when `highlighted`. CSS `group-hover:-translate-y-1` — no `motion/react`. |
| **[ProjectCartridge](src/components/ui/pixel/project-cartridge.tsx)** | `/projects/[slug]` detail header | Async server. Inset `PixelPanel` cartridge label, `BorderBeam` when featured. Syne title, lg pitch, `<dl>` for role / stack / live+source actions. Mobile: actions strip scrolls horizontally. |
| **[ArchiveTile](src/components/ui/pixel/archive-tile.tsx)** | Homepage Creative Archive section | Client (matches GalleryBentoTile — needs `useTranslations`). `aspect: 1/1 \| 3/2 \| 4/5 \| 16/9`. `bg-cyber-grid` shows through while image loads. Spine chip with collection + frame-type. |

Each primitive ships a Storybook story (Default + variants) using real content fixtures (`allProjects[0]`, `galleryItems[0]`) — same pattern as the existing [project-card.stories.tsx](src/components/cards/project-card.stories.tsx).

### Migrations

- **[page.tsx](src/app/[locale]/page.tsx)** — featured row: `ProjectCard` → `MissionModuleCard` (3 line swap, same `highlighted={index === 0}` pattern). Creative Archive bento: drops the `BentoGrid` + `GalleryBentoTile` for a plain `grid gap-3 sm:grid-cols-2` + `ArchiveTile`. The first tile keeps `aspect=\"4/5\"`, the rest go `1/1`.
- **[projects/[slug]/page.tsx](src/app/[locale]/projects/[slug]/page.tsx)** — header: `CaseStudyHeader` → `ProjectCartridge`. Adds the `locale` prop (Cartridge needs it for the typed back link + `Categories` namespace).

No translation keys added — Phase 5 reuses existing `Projects.role`/`stack`/`live`/`source`, `CaseStudy.projectsIndex`/`links`, `Categories.*`, `Gallery.openFrame`/`frameTbd`.

## Validation results

- ✅ `npm run validate` — silent.
- ✅ `npm run build-storybook` — clean.
- ✅ `npm run test:e2e` — **96 / 96 passed** across 360 / 390 / 768 / 1280 / 1920 + Chromium.

## Code-reviewer pass

**0 BLOCK / 2 SHOULD-FIX (both applied) / 4 NIT.** Applied:

- **DraftBadge dropped from ProjectCartridge.** Was passing the raw enum (`coming-soon`, `placeholder`) as the visible label and duplicating the `SystemBadge` above it (which already shows a friendly localized-ish label).
- **`duration-500` → `duration-(--motion-slow)`** in ArchiveTile cover transition. Same 500ms, but token-aligned with the rest of the layer.
- **ZhLocale story re-localizes args.** `ProjectCartridge`'s ZhLocale story was passing English `title`/`shortPitch`/`role` from the default args, which made the ZH render dishonest. Now uses `localize(sample, \"zh\")`.

Acknowledged without change: `MissionModuleCard` `aria-label` intentionally overrides the verbose visible content (h3 + pitch + chips) per §4.4 a11y note (\"title is the link text\") — keeps screen-reader announcement focused on the project title rather than reading the whole card.

## Workflow

PR #50 merged at `643f383`. No leaked dev server this round. Branched off updated main cleanly. Unrelated `.claude/settings.json` stayed out of the commit (sixth phase in a row).

## Test plan

- [x] `npm run validate` silent.
- [x] `npm run build-storybook` passes; eight new stories render.
- [x] `npm run test:e2e` passes (including `/en/projects/nimbus` which now uses ProjectCartridge).
- [x] No new dependencies; no `next.config.ts` / `tsconfig.json` / `package.json` changes.
- [x] Legacy components untouched — `/projects`, `/games/[slug]`, `/gallery` continue rendering with their prior primitives.
- [x] No new translation keys; existing keys verified present in EN and ZH.
- [ ] *Follow-up* (Phase 5.1 or 8): migrate `/games/[slug]` header to a `GameCartridge` variant + `/gallery` tiles to `ArchiveTile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)