### PR TITLE
feat(motion): pixel transitions + microinteractions

### DIFF
--- a/src/app/[locale]/gallery/[collection]/loading.tsx
+++ b/src/app/[locale]/gallery/[collection]/loading.tsx
@@ -1,0 +1,8 @@
+/**
+ * Shadow loading boundary — prevents the parent `gallery/loading.tsx`
+ * curtain from painting when navigating into a collection page. The
+ * collection grid carries its own per-tile BlurFade reveal.
+ */
+export default function Loading() {
+  return null;
+}

--- a/src/app/[locale]/gallery/loading.tsx
+++ b/src/app/[locale]/gallery/loading.tsx
@@ -1,0 +1,10 @@
+import { PixelTransitionOverlay } from "@/components/ui/pixel/pixel-transition-overlay";
+
+/**
+ * App Router loading state for /gallery. Uses a left-to-right wipe so
+ * the gallery's contact-sheet grid reveals across the screen rather
+ * than dropping in from the top. Phase 6.
+ */
+export default function Loading() {
+  return <PixelTransitionOverlay mode="wipe-r" duration="medium" />;
+}

--- a/src/app/[locale]/gallery/saved/loading.tsx
+++ b/src/app/[locale]/gallery/saved/loading.tsx
@@ -1,0 +1,8 @@
+/**
+ * Shadow loading boundary — `gallery/saved` is a private bookmark
+ * surface, not part of the public gallery navigation. Skipping the
+ * parent curtain keeps the surface feeling instant.
+ */
+export default function Loading() {
+  return null;
+}

--- a/src/app/[locale]/projects/[slug]/loading.tsx
+++ b/src/app/[locale]/projects/[slug]/loading.tsx
@@ -1,0 +1,9 @@
+/**
+ * Shadow loading boundary — prevents the parent `projects/loading.tsx`
+ * curtain from painting on `/projects/[slug]` detail-route navigations.
+ * The detail page handles its own progressive reveal via the
+ * PixelTransitionOverlay-free ProjectCartridge entrance animation.
+ */
+export default function Loading() {
+  return null;
+}

--- a/src/app/[locale]/projects/loading.tsx
+++ b/src/app/[locale]/projects/loading.tsx
@@ -1,0 +1,10 @@
+import { PixelTransitionOverlay } from "@/components/ui/pixel/pixel-transition-overlay";
+
+/**
+ * App Router loading state for /projects. Renders a stepped top-down
+ * curtain via PixelTransitionOverlay (Phase 6) while the route resolves.
+ * The page header / footer stay visible because layout.tsx wraps this.
+ */
+export default function Loading() {
+  return <PixelTransitionOverlay mode="dither" duration="medium" />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -302,6 +302,35 @@ body {
   to   { transform: translateX(-50%) }
 }
 
+/* Phase 6 — pixel transition + status pulse keyframes.
+ * Paired with --ease-pixel-step (steps(6,end)) from @theme inline so the
+ * curtain reads as a low-frame-rate dither rather than a smooth slide.
+ * `prefers-reduced-motion` is already neutralized globally below — these
+ * animations become 1ms no-ops under that flag, no extra guard needed. */
+@keyframes pixel-curtain-down {
+  from { transform: translateY(-100%); }
+  to   { transform: translateY(0); }
+}
+
+@keyframes pixel-curtain-wipe-l {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+@keyframes pixel-curtain-wipe-r {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
+}
+
+/* Status pulse — opacity 1 → 0 while scaling out. Eased with
+ * --ease-premium (not pixel-step) so the halo bloom reads as a soft
+ * radar ping; only the curtain animations use the stepped easing. */
+@keyframes pulse-halo {
+  0%   { opacity: 0.85; transform: scale(1); }
+  60%  { opacity: 0; transform: scale(2.6); }
+  100% { opacity: 0; transform: scale(2.6); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/components/ui/pixel/pixel-transition-overlay.stories.tsx
+++ b/src/components/ui/pixel/pixel-transition-overlay.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PixelTransitionOverlay } from "./pixel-transition-overlay";
+
+const meta = {
+  title: "ui/pixel/PixelTransitionOverlay",
+  component: PixelTransitionOverlay,
+  decorators: [
+    (Story) => (
+      // Constrains the fixed overlay to the story canvas so the
+      // animation is observable in Storybook. In production the
+      // component is fixed to the viewport.
+      <div className="relative h-[20rem] w-full overflow-hidden border border-border bg-cyber-grid">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PixelTransitionOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DitherDown: Story = { args: { mode: "dither", duration: "medium" } };
+export const WipeLeft: Story = { args: { mode: "wipe-l", duration: "medium" } };
+export const WipeRight: Story = { args: { mode: "wipe-r", duration: "medium" } };
+export const Slow: Story = { args: { mode: "dither", duration: "slow" } };
+export const Cinematic: Story = { args: { mode: "dither", duration: "cinematic" } };

--- a/src/components/ui/pixel/pixel-transition-overlay.tsx
+++ b/src/components/ui/pixel/pixel-transition-overlay.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Mode = "dither" | "wipe-l" | "wipe-r";
+type Duration = "medium" | "slow" | "cinematic";
+
+const ANIMATION_NAME: Record<Mode, string> = {
+  dither: "pixel-curtain-down",
+  "wipe-l": "pixel-curtain-wipe-l",
+  "wipe-r": "pixel-curtain-wipe-r",
+};
+
+const DURATION_VAR: Record<Duration, string> = {
+  medium: "var(--motion-medium)",
+  slow: "var(--motion-slow)",
+  cinematic: "var(--motion-cinematic)",
+};
+
+interface PixelTransitionOverlayProps {
+  /** Direction of the curtain reveal. Defaults to `"dither"` (top-down). */
+  mode?: Mode;
+  /** Duration token. Defaults to `"medium"` (--motion-medium / 280ms). */
+  duration?: Duration;
+  className?: string;
+}
+
+/**
+ * Fixed-position scene-change curtain. Drop it into a Next App Router
+ * `loading.tsx` to paint a stepped reveal while the next route prepares.
+ * Uses keyframes from `globals.css` + the Phase-1 `--ease-pixel-step`
+ * easing token; the curtain is `pointer-events-none` and `aria-hidden`
+ * so it never traps focus or steals clicks.
+ *
+ * Reduced-motion: the universal `transition-duration` / `animation-duration`
+ * override in globals.css collapses the curtain to a 1ms no-op, matching
+ * the §4.9 a11y spec without requiring an inline `useReducedMotion` check.
+ */
+export function PixelTransitionOverlay({
+  mode = "dither",
+  duration = "medium",
+  className,
+}: PixelTransitionOverlayProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none fixed inset-0 z-40 overflow-hidden",
+        className,
+      )}
+    >
+      {/* Inline `style.animation` (rather than a Tailwind utility class)
+        * because Tailwind v4's `animate-[name_duration_ease]` arbitrary
+        * value syntax cannot reference CSS variables in the duration
+        * slot — and we want the curtain to inherit `--motion-medium /
+        * slow / cinematic` from the theme rather than hardcoding ms. */}
+      <div
+        className="absolute inset-0 bg-background"
+        style={{
+          animation: `${ANIMATION_NAME[mode]} ${DURATION_VAR[duration]} var(--ease-pixel-step) both`,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/pixel/status-pulse.stories.tsx
+++ b/src/components/ui/pixel/status-pulse.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { StatusPulse } from "./status-pulse";
+
+const meta = {
+  title: "ui/pixel/StatusPulse",
+  component: StatusPulse,
+  decorators: [
+    (Story) => (
+      <div className="flex h-16 items-center justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StatusPulse>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Live: Story = { args: { tone: "live" } };
+export const Now: Story = { args: { tone: "now" } };
+export const Info: Story = { args: { tone: "info" } };
+
+export const LiveLarge: Story = { args: { tone: "live", size: "md" } };
+export const NowLarge: Story = { args: { tone: "now", size: "md" } };

--- a/src/components/ui/pixel/status-pulse.tsx
+++ b/src/components/ui/pixel/status-pulse.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Tone = "live" | "now" | "info";
+type Size = "sm" | "md";
+
+const DOT_CLASS: Record<Tone, string> = {
+  live: "bg-signal",
+  now: "bg-success",
+  info: "bg-muted-foreground",
+};
+
+const SIZE_CLASS: Record<Size, string> = {
+  sm: "size-1.5",
+  md: "size-2",
+};
+
+interface StatusPulseProps {
+  /** "live" and "now" pulse; "info" stays static. */
+  tone?: Tone;
+  size?: Size;
+  className?: string;
+}
+
+/**
+ * Small live / now / info indicator. The halo ring animates via the
+ * `pulse-halo` keyframe in `globals.css`; under reduced-motion the
+ * universal `animation-iteration-count: 1` override collapses the
+ * infinite loop to a single near-instant tick. Always render this
+ * inside an outer element that carries the semantic role+aria-live
+ * (e.g. SystemBadge) — the pulse itself is purely decorative.
+ */
+export function StatusPulse({
+  tone = "info",
+  size = "sm",
+  className,
+}: StatusPulseProps) {
+  const dotColor = DOT_CLASS[tone];
+  const animates = tone !== "info";
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative inline-flex shrink-0",
+        SIZE_CLASS[size],
+        className,
+      )}
+    >
+      {animates ? (
+        <span
+          className={cn("absolute inset-0 rounded-full opacity-0", dotColor)}
+          style={{
+            animation:
+              "pulse-halo var(--motion-cinematic) var(--ease-premium) infinite",
+          }}
+        />
+      ) : null}
+      <span
+        className={cn(
+          "relative inline-block size-full rounded-full",
+          dotColor,
+        )}
+      />
+    </span>
+  );
+}

--- a/src/components/ui/pixel/system-badge.tsx
+++ b/src/components/ui/pixel/system-badge.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { z } from "zod";
 import { Badge } from "../badge";
+import { StatusPulse } from "./status-pulse";
 import { cn } from "@/lib/utils";
 import { contentStatusSchema } from "@/content/schemas";
 
@@ -70,9 +71,9 @@ export function SystemBadge({
   const resolved =
     label ??
     (status ? STATUS_LABEL[status] : kind ? KIND_LABEL[kind] : "Info");
-  // `live` and `now` will pulse in Phase 6 via the dedicated StatusPulse
-  // primitive. For now the dot is static; the accessibility hooks are
-  // already in place so AT users hear updates once the visual pulse lands.
+  // `live` and `now` render a pulsing halo via the StatusPulse primitive
+  // (Phase 6). The outer Badge carries role="status" + aria-live="polite"
+  // so AT users hear updates; the pulse itself is purely decorative.
   const isLive = kind === "live" || kind === "now";
 
   return (
@@ -83,10 +84,14 @@ export function SystemBadge({
       aria-live={isLive ? "polite" : undefined}
       {...rest}
     >
-      <span
-        aria-hidden="true"
-        className={cn("size-1.5 rounded-full", DOT_CLASS[tone])}
-      />
+      {isLive ? (
+        <StatusPulse tone={kind === "live" ? "live" : "now"} />
+      ) : (
+        <span
+          aria-hidden="true"
+          className={cn("size-1.5 rounded-full", DOT_CLASS[tone])}
+        />
+      )}
       <span>{resolved}</span>
     </Badge>
   );


### PR DESCRIPTION
## Summary

Phase 6 of [docs/UNIFIED_VISUAL_DIRECTION.md](docs/UNIFIED_VISUAL_DIRECTION.md) (§4.9 + §4.13 + §7.2). Two new motion primitives, four new CSS keyframes, StatusPulse wired into `SystemBadge`, and pixel-curtain `loading.tsx` boundaries shipped for `/projects` and `/gallery` (with shadow no-op boundaries scoped to the list routes only).

### New primitives

| Primitive | Job | Reduced-motion |
| --- | --- | --- |
| **[PixelTransitionOverlay](src/components/ui/pixel/pixel-transition-overlay.tsx)** | Fixed-position scene-change curtain. Three modes (`dither` / `wipe-l` / `wipe-r`), token-driven duration. | Globals.css universal `animation-duration: 1ms !important` collapses the curtain to a no-op. |
| **[StatusPulse](src/components/ui/pixel/status-pulse.tsx)** | Decorative `<span>` halo that pulses for `live` / `now` and stays static for `info`. | Same universal override forces `animation-iteration-count: 1` — halo plays one ~1ms tick. |

Both ship Storybook stories.

### Integration

- **[SystemBadge](src/components/ui/pixel/system-badge.tsx)** — swaps the prior static inline dot for `<StatusPulse>` when `kind === \"live\" | \"now\"`. The Badge's `role=\"status\"` + `aria-live=\"polite\"` from Phase 2 are preserved; `StatusPulse` itself is `aria-hidden` (the badge owns the announcement).
- **[src/app/[locale]/projects/loading.tsx](src/app/[locale]/projects/loading.tsx)** — top-down dither curtain.
- **[src/app/[locale]/gallery/loading.tsx](src/app/[locale]/gallery/loading.tsx)** — left-to-right wipe curtain.
- **Shadow boundaries** at `[slug]/loading.tsx`, `[collection]/loading.tsx`, `saved/loading.tsx` return `null` to prevent the parent curtain from cascading into detail / private routes (caught in pre-commit review).

### CSS

[globals.css](src/app/globals.css) gains four `@keyframes` next to the existing `marquee` keyframe: `pixel-curtain-down`, `pixel-curtain-wipe-l`, `pixel-curtain-wipe-r`, `pulse-halo`. Reduced-motion is already handled globally below; no per-keyframe guard needed.

### Deferred to a later PR

**Dialog/Sheet integration.** Wiring `PixelTransitionOverlay` into Radix `Dialog.Overlay` risks interfering with click-outside-to-close and benefits from its own scrutiny. The doc's §4.9 prescribes that integration but the Phase-6 spec scopes loading boundaries first.

## Validation results

- ✅ `npm run validate` — silent.
- ✅ `npm run build-storybook` — clean.
- ✅ `npm run test:e2e` — **96 / 96 passed** across 360 / 390 / 768 / 1280 / 1920 + Chromium. Run twice — once before the shadow-loading fix caught the cascade behavior, once after.

## Code-reviewer pass

**0 BLOCK / 1 SHOULD-FIX (applied) / 4 NIT.** Applied:

- **Shadow `loading.tsx` at `[slug]`, `[collection]`, `saved`.** Reviewer flagged that Next App Router cascades a parent segment's `loading.tsx` to every nested child — so without these no-op boundaries the curtain would paint on `/projects/[slug]` and inside collection pages too. Three one-line files fix it.
- **Inline-style comment** on `PixelTransitionOverlay` explaining why a Tailwind utility isn't usable (Tailwind v4 `animate-[name_duration_ease]` arbitrary value can't reference CSS variables in the duration slot).

NITs acknowledged without change: status-pulse comment nuance, `tone` default (\"info\" is safe), story naming asymmetry.

## Workflow

PR #51 merged at `6d3d528`. No leaked dev server this round. Seven PRs in a row keeping the unrelated `.claude/settings.json` modification out of the commit.

## Test plan

- [x] `npm run validate` silent.
- [x] `npm run build-storybook` passes; ten new stories render.
- [x] `npm run test:e2e` passes the full viewport matrix.
- [x] No new dependencies; no `next.config.ts` / `tsconfig.json` / `package.json` changes.
- [x] Shadow loading boundaries scope the curtain to list routes only.
- [ ] *Follow-up*: Dialog/Sheet `Overlay` integration for the same dither curtain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)