### PR TITLE
chore(pixel): stabilize cyber-pixel foundation

### DIFF
--- a/src/components/sections/command-hero.stories.tsx
+++ b/src/components/sections/command-hero.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import zhMessages from "../../../messages/zh.json";
+import { CommandHero } from "./command-hero";
+
+const meta = {
+  title: "Sections/CommandHero",
+  component: CommandHero,
+  decorators: [
+    (Story) => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CommandHero>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithStatus: Story = {
+  args: {
+    status: {
+      label: "Nimbus · secure file vault",
+      href: "/projects/nimbus",
+      accessibleLabel: "Open Nimbus case study",
+    },
+  },
+};
+
+export const ZhLocale: Story = {
+  args: {
+    versionLabel: "v2027",
+    markGlyph: `> M4RKYU
+> 系统在线
+> 工程师 · 艺术家 · 开发者`,
+    status: {
+      label: "Nimbus · 安全文件库",
+      href: "/projects/nimbus",
+      accessibleLabel: "打开 Nimbus 案例研究",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <NextIntlClientProvider locale="zh" messages={zhMessages}>
+        <Story />
+      </NextIntlClientProvider>
+    ),
+  ],
+};

--- a/src/components/sections/game-hud.stories.tsx
+++ b/src/components/sections/game-hud.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import zhMessages from "../../../messages/zh.json";
+import { GameHud } from "./game-hud";
+
+// GameHud composes LanguageSwitcher / ThemeSwitcher / SoundToggle, all
+// of which render tooltips. Provide a TooltipProvider so the embedded
+// triggers don't throw outside the real `[locale]/layout.tsx` shell.
+const meta = {
+  title: "Sections/GameHud",
+  component: GameHud,
+  decorators: [
+    (Story) => (
+      <TooltipProvider delayDuration={200}>
+        <div className="max-w-2xl">
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+  args: {
+    hint: ">_ press ⌘K",
+    ariaLabel: "System status",
+  },
+} satisfies Meta<typeof GameHud>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const ZhLocale: Story = {
+  args: {
+    hint: ">_ 按 ⌘K",
+    ariaLabel: "系统状态",
+  },
+  decorators: [
+    (Story) => (
+      <NextIntlClientProvider locale="zh" messages={zhMessages}>
+        <Story />
+      </NextIntlClientProvider>
+    ),
+  ],
+};

--- a/src/components/sections/game-hud.tsx
+++ b/src/components/sections/game-hud.tsx
@@ -28,21 +28,30 @@ export function GameHud({ hint, ariaLabel, className }: GameHudProps) {
   return (
     <nav
       aria-label={ariaLabel}
-      className={cn(
-        "flex flex-wrap items-center gap-x-4 gap-y-3 border-t border-border/60 pt-4",
-        className,
-      )}
+      className={cn("border-t border-border/60 pt-4", className)}
     >
-      <LanguageSwitcher />
-      <ThemeSwitcher />
-      <SoundToggle />
-      {/* `font-pixel` is safe now that [locale]/layout.tsx propagates
-        * `lang={locale}` to the DOM — the `:lang(zh)` guard in
-        * globals.css redirects --font-pixel to the display stack on
-        * the zh route, so "按" never reaches the VT323 fallback. */}
-      <span className="ml-auto font-pixel text-base uppercase tracking-[0.12em] text-muted-foreground">
-        {hint}
-      </span>
+      {/* `<ul>` carries the flex layout so screen readers announce a
+       * 4-item list ("locale, theme, sound, ⌘K hint") instead of a
+       * flat run of controls. `list-none` defends against UA defaults
+       * even though Tailwind preflight already strips list-style. */}
+      <ul className="flex list-none flex-wrap items-center gap-x-4 gap-y-3 p-0">
+        <li>
+          <LanguageSwitcher />
+        </li>
+        <li>
+          <ThemeSwitcher />
+        </li>
+        <li>
+          <SoundToggle />
+        </li>
+        {/* `font-pixel` is safe now that [locale]/layout.tsx propagates
+          * `lang={locale}` to the DOM — the `:lang(zh)` guard in
+          * globals.css redirects --font-pixel to the display stack on
+          * the zh route, so "按" never reaches the VT323 fallback. */}
+        <li className="ml-auto font-pixel text-base uppercase tracking-[0.12em] text-muted-foreground">
+          {hint}
+        </li>
+      </ul>
     </nav>
   );
 }

--- a/src/components/system/sound-toggle.stories.tsx
+++ b/src/components/system/sound-toggle.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NextIntlClientProvider } from "next-intl";
+import { useEffect } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import zhMessages from "../../../messages/zh.json";
+import { SoundToggle } from "./sound-toggle";
+
+// The toggle has no `enabled` prop — state lives in localStorage under
+// `m4rkyu.sound`. Stories that need the "on" visual pre-seed that key
+// before the component mounts so `useSyncExternalStore`'s client
+// snapshot reads `true` on the very first paint.
+const SOUND_STORAGE_KEY = "m4rkyu.sound";
+
+function SeedSoundState({
+  enabled,
+  children,
+}: {
+  enabled: boolean;
+  children: React.ReactNode;
+}) {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(SOUND_STORAGE_KEY, enabled ? "on" : "off");
+  }
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(SOUND_STORAGE_KEY);
+      }
+    };
+  }, []);
+  return <>{children}</>;
+}
+
+const meta = {
+  title: "System/SoundToggle",
+  component: SoundToggle,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <TooltipProvider delayDuration={200}>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+} satisfies Meta<typeof SoundToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <SeedSoundState enabled={false}>
+        <Story />
+      </SeedSoundState>
+    ),
+  ],
+};
+
+export const Enabled: Story = {
+  decorators: [
+    (Story) => (
+      <SeedSoundState enabled={true}>
+        <Story />
+      </SeedSoundState>
+    ),
+  ],
+};
+
+export const ZhLocale: Story = {
+  decorators: [
+    (Story) => (
+      <NextIntlClientProvider locale="zh" messages={zhMessages}>
+        <SeedSoundState enabled={false}>
+          <Story />
+        </SeedSoundState>
+      </NextIntlClientProvider>
+    ),
+  ],
+};

--- a/src/components/ui/pixel/pixel-transition-overlay.tsx
+++ b/src/components/ui/pixel/pixel-transition-overlay.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import * as React from "react";
+import { useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
 
 type Mode = "dither" | "wipe-l" | "wipe-r";
@@ -31,15 +34,18 @@ interface PixelTransitionOverlayProps {
  * easing token; the curtain is `pointer-events-none` and `aria-hidden`
  * so it never traps focus or steals clicks.
  *
- * Reduced-motion: the universal `transition-duration` / `animation-duration`
- * override in globals.css collapses the curtain to a 1ms no-op, matching
- * the §4.9 a11y spec without requiring an inline `useReducedMotion` check.
+ * Reduced-motion: short-circuits to `null` via `useReducedMotion()` so
+ * the keyframe never runs at all. The globals.css `animation-duration`
+ * override stays as a backstop for any other animated surface.
  */
 export function PixelTransitionOverlay({
   mode = "dither",
   duration = "medium",
   className,
 }: PixelTransitionOverlayProps) {
+  const reduceMotion = useReducedMotion();
+  if (reduceMotion) return null;
+
   return (
     <div
       aria-hidden="true"

--- a/src/components/ui/pixel/status-pulse.tsx
+++ b/src/components/ui/pixel/status-pulse.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import * as React from "react";
+import { useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
 
 type Tone = "live" | "now" | "info";
@@ -24,19 +27,20 @@ interface StatusPulseProps {
 
 /**
  * Small live / now / info indicator. The halo ring animates via the
- * `pulse-halo` keyframe in `globals.css`; under reduced-motion the
- * universal `animation-iteration-count: 1` override collapses the
- * infinite loop to a single near-instant tick. Always render this
- * inside an outer element that carries the semantic role+aria-live
- * (e.g. SystemBadge) — the pulse itself is purely decorative.
+ * `pulse-halo` keyframe in `globals.css`. Under reduced-motion the
+ * halo is skipped entirely (via `useReducedMotion()`) and only the
+ * steady dot renders. Always render this inside an outer element
+ * that carries the semantic role+aria-live (e.g. SystemBadge) — the
+ * pulse itself is purely decorative.
  */
 export function StatusPulse({
   tone = "info",
   size = "sm",
   className,
 }: StatusPulseProps) {
+  const reduceMotion = useReducedMotion();
   const dotColor = DOT_CLASS[tone];
-  const animates = tone !== "info";
+  const animates = tone !== "info" && !reduceMotion;
 
   return (
     <span


### PR DESCRIPTION
## Summary
PR #57 in the roadmap defined by [#56](https://github.com/zhenxiao-yu/M4rkyu.com/pull/56). Closes the Phase-8 deferred items tracked in `docs/FINAL_SITE_ARCHITECTURE.md` §13.

- **Reduced-motion early-returns** — `PixelTransitionOverlay` and `StatusPulse` now consult `useReducedMotion()` from `motion/react` (the dominant pattern in this repo) and skip the animation entirely when the user prefers reduced motion. The global 1ms CSS override in `globals.css` is preserved as a backstop.
- **GameHud nav semantics** — `<nav aria-label><ul><li>×4</li></ul></nav>` so SR users hear list shape instead of a flat run of controls. No visual change.
- **Storybook coverage matrix** — backfilled the three primitives that had no stories at all: `SoundToggle`, `CommandHero`, `GameHud`. Each gets a `ZhLocale` story.
- **Token-only audit** — read-only sweep across `src/components/ui/pixel/**`. Zero violations (no `bg-zinc-*`, no hex literals, no inline-style colors). Documented in the commit; no code change required.

## Why
Phase-8 shipped foundation components but left four accessibility / coverage items as "deferred-cosmetic" in `PHASE_8_AUDIT.md`. They were small individually but accumulated risk if left open. The architecture doc in PR #56 promised they'd land in PR #57; this is that PR.

## Files changed
| Type | File |
| ---- | ---- |
| Edit | [src/components/ui/pixel/pixel-transition-overlay.tsx](src/components/ui/pixel/pixel-transition-overlay.tsx) |
| Edit | [src/components/ui/pixel/status-pulse.tsx](src/components/ui/pixel/status-pulse.tsx) |
| Edit | [src/components/sections/game-hud.tsx](src/components/sections/game-hud.tsx) |
| New  | [src/components/system/sound-toggle.stories.tsx](src/components/system/sound-toggle.stories.tsx) |
| New  | [src/components/sections/command-hero.stories.tsx](src/components/sections/command-hero.stories.tsx) |
| New  | [src/components/sections/game-hud.stories.tsx](src/components/sections/game-hud.stories.tsx) |

## Test plan
- [x] \`npm run typecheck\` — clean.
- [x] \`npm run lint\` — clean.
- [ ] System-level: enable \`prefers-reduced-motion: reduce\` and navigate between routes — confirm no curtain animation.
- [ ] Storybook: \`npm run storybook\` — confirm new stories render and zh-locale variants display Chinese strings.
- [ ] Screen reader sweep: NVDA or VoiceOver across the header — confirm GameHud announces \"List with 4 items\" rather than a flat control run.

## Follow-ups deferred to a smaller PR
Dark-mode and zh-locale story variants for the seven existing pixel stories that lack them (PixelPanel, PixelButton, SystemBadge, SectionFrame, StatusPulse, PixelTransitionOverlay, MissionModuleCard, ProjectCartridge). Tracked as a fast-win — not foundation-blocking.

## Stacking
This PR branches from \`main\`, not from #56. The two are mergeable in either order. The architecture doc in #56 is descriptive; this PR is the corresponding implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)