### PR TITLE
chore(perf): audit and optimize first-load performance

### DIFF
--- a/docs/PERFORMANCE_AUDIT.md
+++ b/docs/PERFORMANCE_AUDIT.md
@@ -1,0 +1,230 @@
+# Performance Audit
+
+Surgical audit of M4RKYU.SYS first-load performance. No redesign, no
+new dependencies, no removal of the cyber-pixel system. Findings and
+fixes target initial JS, image strategy, atmospheric effects, fonts,
+and per-route budgets.
+
+## 1. Measurement constraints
+
+- **Local production build (Windows, H: drive):** blocked by a known
+  `readlink EISDIR` on `src/app/robots.ts` regardless of
+  `NEXT_DIST_DIR`. Same caveat documented in [CLAUDE.md](../CLAUDE.md).
+- **CI / Vercel build:** green on every recent PR — bundle sizes
+  recorded there are the source of truth. Re-measure against the
+  Vercel preview deployed for this PR.
+- **Speed Insights:** `@vercel/speed-insights` is already wired into
+  the root layout — field data accumulates on production.
+- **Lighthouse:** must be run against the Vercel preview (local build
+  blocked).
+
+This audit therefore relies on (a) the most recent CI build output,
+(b) static analysis of the source tree, (c) explicit reasoning about
+what is and is not in the initial JS payload.
+
+## 2. Likely LCP element per route
+
+| Route        | Likely LCP element                              | Strategy in place |
+| ------------ | ----------------------------------------------- | ----------------- |
+| `/`          | `<h1>` headline inside `HeroSection`            | Text. No image to prioritize. `BlurFade` wraps the column — animates after hydration, not before paint. |
+| `/work`      | Section heading + first project tile            | Text + lazy `next/image` for tile thumbs. |
+| `/work/[slug]` | Cover image in case-study hero                | `priority` set on the cover `<Image>` ([work/[slug]/page.tsx:113](../src/app/[locale]/work/[slug]/page.tsx#L113)). |
+| `/archive`   | First gallery tile (above the fold)             | `<Image fill sizes=...>`, no `priority`. Acceptable: text heading paints first; tile fades in. |
+| `/archive/[collection]` | Collection hero image                | `<Image fill sizes=...>`. Add `priority` for first tile when collection has a hero — TODO follow-up. |
+| `/logs`      | Pinned post card hero                            | `<Image>` with `sizes`. Adequate. |
+| `/logs/[slug]` | Post hero / first inline image                 | Markdown-driven; first image is lazy-loaded via `post-body.tsx`. |
+| `/games`     | First game tile                                  | Lazy image. |
+| `/games/[slug]` | Cover image                                   | `priority` set ([games/[slug]/page.tsx:100](../src/app/[locale]/games/[slug]/page.tsx#L100)). |
+| `/portal`    | Particles canvas + headline text                 | Canvas mounts post-hydration; text is LCP. |
+
+## 3. INP risks
+
+- **Lenis smooth scroll** (`src/providers/smooth-scroll.tsx`) runs a
+  `requestAnimationFrame` loop on every route, no
+  `prefers-reduced-motion` gate. Intercepts scroll/wheel events on
+  every viewport. **Fix below.**
+- **Particles canvas** ([particles.tsx](../src/components/ui/magic/particles.tsx))
+  already short-circuits on reduced motion and is canvas-based, not
+  DOM. Scoped to `/portal`. **OK.**
+- **CommandPalette** mounts cmdk + `lucide-react` icons + the entire
+  `galleryItems` content payload in the initial bundle on every route
+  because `CommandPaletteProvider` statically imports
+  `CommandPalette`. **Fix: lazy-load via `next/dynamic`.**
+- **StatusPulse halo** ([status-pulse.tsx](../src/components/ui/pixel/status-pulse.tsx))
+  short-circuits on reduced motion. Halo lives next to status text;
+  not infinite offscreen. **OK.**
+- **`IntroLoader`** is a one-shot, session-gated full-viewport
+  overlay. On repeat visits it skips entirely; on reduced motion it
+  skips entirely. Component code lives in its own client chunk
+  (Next splits "use client" components by default). Marginal
+  savings from further deferral did not justify the wrapper-file
+  cost. **Left as-is. Re-evaluate if Lighthouse flags it.**
+
+## 4. CLS risks
+
+- All `next/image` usage either uses `fill` inside an aspect-locked
+  container OR explicit `width`/`height` (post-body Markdown images).
+  No raw `<img>` tags. **OK.**
+- Fonts: `next/font/google` with the default `display: swap`. Latin
+  subsets only, CJK on system fallback by design. Variables on
+  `<html>` so no shift on hydration. **OK.**
+- `IntroLoader` returns `null` on SSR and only mounts after
+  hydration — no CLS, no reserved space.
+
+## 5. Heavy client components (initial bundle inventory)
+
+Mounted in the root layout, ships on every page:
+
+- `SmoothScroll` → pulls **Lenis (~13 KB gz)** plus a RAF loop.
+- `Analytics` + `SpeedInsights` (Vercel, server-rendered shells).
+
+Mounted in `[locale]/layout.tsx`, ships on every locale page:
+
+- `NextIntlClientProvider` — required for client `useTranslations`.
+- `ThemeProvider` (`next-themes`) — required for dark/light.
+- `TooltipProvider` (Radix) — required for any `<Tooltip>` consumer.
+- `CommandPaletteProvider` → statically imports `CommandPalette`,
+  which pulls in **cmdk + 14 lucide icons + Radix Dialog + the entire
+  `galleryItems` content payload + `PalettePost` slice**. The dialog
+  body only renders when `open=true`, but the JavaScript ships
+  regardless.
+
+Per-page hot spots:
+
+- `/archive` eagerly imports `GalleryLightbox` (Dialog + Image +
+  per-frame logic) even though the lightbox only opens on click.
+- `/` eagerly imports `IntroLoader` (motion + AnimatePresence) even
+  though it only renders on the first visit of a session.
+
+## 6. Heavy media
+
+- No above-the-fold full-bleed hero image anywhere. The home hero is
+  type-first. Other hero routes set `priority` on the LCP image
+  correctly.
+- Gallery uses `<Image fill>` thumbnails with `grayscale` filter +
+  scale on hover. Lightbox loads full-size images only when opened.
+- dev.to-syndicated Markdown images route through `next/image` with
+  remote-pattern config in `next.config.ts` — Next optimizes them.
+
+## 7. Third-party scripts
+
+- `@vercel/analytics` and `@vercel/speed-insights` — both inject a
+  tiny script only on production. Acceptable.
+- `dev.to` API is server-side fetched (`src/lib/blog/devto.ts`) and
+  cached. No client request.
+- No Google Analytics, no Sentry, no Intercom, no tag manager.
+
+## 8. Atmospheric effects audit
+
+| Effect | Location | Status |
+| ------ | -------- | ------ |
+| `noise-layer` + `scanline-layer` | hero section | CSS-only. No JS cost. |
+| `Particles` canvas | `/portal` only | Reduced-motion gated. Canvas, not DOM. |
+| `PixelTransitionOverlay` | route transitions | Reduced-motion → returns null. Phase-9 fix. |
+| `StatusPulse` halo | status badges | Reduced-motion skips halo. Phase-9 fix. |
+| Lenis smooth scroll | every route | **No reduced-motion gate.** Fix below. |
+| `BlurFade`, `FadeIn`, `Stagger` | content sections | `BlurFade` uses `useReducedMotion`. Others use `viewport whileInView` — animations only fire on visible content, so offscreen sections don't run. |
+
+## 9. Fonts
+
+- `Geist`, `Geist_Mono`, `Syne`, `VT323` — all via `next/font/google`.
+- All subsets restricted to `["latin"]`. CJK uses system fallback by
+  design (per [globals.css](../src/app/globals.css) `:lang(zh)` guard).
+- Default `display: swap` is correct for portfolio use (no FOIT).
+- No new font additions planned.
+
+## 10. Prioritized fixes (this PR)
+
+The fixes below are all surgical, behavior-preserving, and do not
+touch the visual direction.
+
+### F.1 — Defer Lenis until after first paint
+
+`SmoothScroll` currently imports `lenis` statically at module load.
+With `next/dynamic` infrastructure-only changes inside the existing
+client component, we switch to a dynamic `import()` inside the
+effect so the ~13 KB Lenis chunk is requested by the browser only
+**after hydration**, not as part of the initial JS bundle. We also
+short-circuit when `prefers-reduced-motion: reduce` is set — no
+Lenis import at all, no RAF loop, native scroll restored.
+
+### F.2 — Lazy-load `CommandPalette` body
+
+`CommandPaletteProvider` keeps the event listener (the Cmd+K hotkey
+that runs cheaply on `keydown`) but the `<CommandPalette>` dialog
+becomes a `next/dynamic` import with `ssr: false`, loaded the first
+time `open` flips to `true`. This pulls cmdk, the 14 lucide icons,
+Radix Dialog, and the `galleryItems` payload out of the initial
+bundle on **every page**.
+
+### F.3 — Lazy-load `GalleryLightbox`
+
+Same pattern. `archive/_client.tsx` (and `saved/page.tsx`) only need
+the lightbox when a user clicks a frame. Wrap in `next/dynamic` so
+the lightbox bundle is fetched on first interaction.
+
+### F.4 — `compiler.removeConsole` in production
+
+Add `compiler: { removeConsole: { exclude: ["error", "warn"] } }`
+to `next.config.ts`. Strips development logs from production
+client bundles. Negligible per file, but the codebase has scattered
+`console.log` calls in motion components and providers.
+
+## 11. Route budgets
+
+These are the initial-JS budgets the project should hold against on
+the Vercel build output. They are *advisory*, not enforced in CI yet.
+A future PR can wire a CI guardrail.
+
+| Route                  | First-load JS (target) | Notes |
+| ---------------------- | ---------------------- | ----- |
+| `/` (home)             | ≤ 220 KB               | Includes shared chunk + intl + theme + nav. After F.2. |
+| `/work`                | ≤ 200 KB               | Server-rendered list + tiny client filter. |
+| `/work/[slug]`         | ≤ 215 KB               | Adds case-study cover image priority. |
+| `/archive`             | ≤ 210 KB               | After F.3 (lightbox lazy). |
+| `/archive/[collection]`| ≤ 215 KB               | After F.3. |
+| `/archive/saved`       | ≤ 210 KB               | After F.3. |
+| `/logs`                | ≤ 215 KB               | Post timeline + toolbar. |
+| `/logs/[slug]`         | ≤ 225 KB               | Reading-progress + post body (shiki is server-only). |
+| `/games`               | ≤ 200 KB               | Server-rendered list. |
+| `/portal`              | ≤ 220 KB               | Includes particles canvas. |
+| `/contact`             | ≤ 200 KB               | Tiny form. |
+
+**Shared baseline (loaded on every route):** ≤ 95 KB. After
+F.1/F.2 this should drop because Lenis + cmdk + lucide-react are
+not in the shared chunk anymore.
+
+## 12. Things explicitly NOT changed
+
+- Cyber-pixel design system: untouched.
+- Visual direction (UNIFIED_VISUAL_DIRECTION.md): untouched.
+- Particles, scanlines, noise, pixel transitions: untouched
+  (already reduced-motion-aware).
+- Fonts, typography, spacing, color tokens: untouched.
+- Routes, IA, nav structure: untouched.
+- Dependencies: nothing added, nothing removed.
+
+## 13. Follow-ups (next PR, not this one)
+
+- Wire `@next/bundle-analyzer` as a dev-only opt-in (`ANALYZE=true
+  npm run build`) — useful but adds a devDependency, defer to a
+  dedicated PR.
+- Enforce route budgets via CI (e.g. a small script that parses the
+  Next build output and fails on regression).
+- Audit `motion` usage and consider `LazyMotion` + feature loading
+  for the home and `/portal` routes if Lighthouse still flags
+  unused JS after F.1–F.5.
+- Confirm Vercel CDN is serving `image/avif` to Lighthouse — the
+  `formats` array already prefers AVIF.
+- Add `priority` to the first `archive/[collection]` hero image if
+  user testing shows that tile is the LCP.
+
+## 14. Verification
+
+After this PR lands, against the Vercel preview:
+
+- Run Lighthouse on `/en` and `/zh` desktop + mobile profiles.
+- Compare first-load JS in Vercel build log against budgets in §11.
+- Confirm Speed Insights field data over 7 days.
+- Smoke test the Cmd+K palette and gallery lightbox to confirm
+  lazy chunks load on first interaction.

--- a/next.config.ts
+++ b/next.config.ts
@@ -49,6 +49,11 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  compiler: {
+    // Strip dev logs from production client bundles. Keep errors and
+    // warnings so real problems still surface in the browser console.
+    removeConsole: { exclude: ["error", "warn"] },
+  },
   images: {
     formats: ["image/avif", "image/webp"],
     // Dev.to-syndicated post bodies (Phase 8.2) reference images

--- a/src/app/[locale]/archive/_client.tsx
+++ b/src/app/[locale]/archive/_client.tsx
@@ -1,15 +1,25 @@
 "use client";
 
 import Image from "next/image";
+import dynamic from "next/dynamic";
 import { useCallback, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { PlaceholderImage } from "@/components/placeholders/placeholder-image";
-import { GalleryLightbox } from "@/components/gallery/gallery-lightbox";
 import type { GalleryItem } from "@/content/schemas";
 import { cn } from "@/lib/utils";
+
+// Lightbox is only needed after a user clicks a frame — defer the
+// Dialog + per-frame controls bundle until first interaction.
+const GalleryLightbox = dynamic(
+  () =>
+    import("@/components/gallery/gallery-lightbox").then(
+      (mod) => mod.GalleryLightbox,
+    ),
+  { ssr: false },
+);
 
 interface GalleryGridProps {
   items: GalleryItem[];
@@ -78,12 +88,14 @@ export function GalleryGrid({ items, locale }: GalleryGridProps) {
         ))}
       </div>
 
-      <GalleryLightbox
-        items={orderedItems}
-        openSlug={frame}
-        locale={locale}
-        onChange={setOpenSlug}
-      />
+      {frame !== null ? (
+        <GalleryLightbox
+          items={orderedItems}
+          openSlug={frame}
+          locale={locale}
+          onChange={setOpenSlug}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/system/command-palette-provider.tsx
+++ b/src/components/system/command-palette-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import {
   createContext,
   useCallback,
@@ -9,7 +10,16 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { CommandPalette, type PalettePost } from "./command-palette";
+import type { PalettePost } from "./command-palette";
+
+// Dynamic import keeps cmdk + Radix Dialog + the lucide icon set +
+// the gallery content payload out of the initial JS bundle on every
+// route. The dialog body is only fetched the first time the user
+// opens the palette (Cmd+K or trigger button).
+const CommandPalette = dynamic(
+  () => import("./command-palette").then((mod) => mod.CommandPalette),
+  { ssr: false },
+);
 
 interface CommandPaletteContextValue {
   open: boolean;
@@ -41,8 +51,20 @@ export function CommandPaletteProvider({
   posts,
 }: CommandPaletteProviderProps) {
   const [open, setOpen] = useState(false);
+  // Latch flips the first time the palette opens so the dynamic
+  // import is initiated only on demand — we keep the chunk mounted
+  // afterwards so subsequent opens are instant.
+  const [hasOpened, setHasOpened] = useState(false);
 
-  const toggle = useCallback(() => setOpen((value) => !value), []);
+  const toggle = useCallback(() => {
+    setOpen((value) => !value);
+    setHasOpened(true);
+  }, []);
+
+  const handleSetOpen = useCallback((next: boolean) => {
+    setOpen(next);
+    if (next) setHasOpened(true);
+  }, []);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -60,14 +82,16 @@ export function CommandPaletteProvider({
   }, [toggle]);
 
   const value = useMemo(
-    () => ({ open, setOpen, toggle }),
-    [open, toggle],
+    () => ({ open, setOpen: handleSetOpen, toggle }),
+    [open, handleSetOpen, toggle],
   );
 
   return (
     <CommandPaletteContext.Provider value={value}>
       {children}
-      <CommandPalette open={open} onOpenChange={setOpen} posts={posts} />
+      {hasOpened ? (
+        <CommandPalette open={open} onOpenChange={handleSetOpen} posts={posts} />
+      ) : null}
     </CommandPaletteContext.Provider>
   );
 }

--- a/src/providers/smooth-scroll.tsx
+++ b/src/providers/smooth-scroll.tsx
@@ -1,25 +1,46 @@
 "use client"
 
-import Lenis from "lenis"
 import { useEffect } from "react"
 
 export function SmoothScroll({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    const lenis = new Lenis({
-      duration: 1.2,
-      easing: (t: number) => 1 - Math.pow(1 - t, 4),
+    // Respect prefers-reduced-motion: native scroll, no Lenis at all,
+    // no RAF loop, no module download.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return
+    }
+
+    let cancelled = false
+    let rafId = 0
+    let cleanup: (() => void) | null = null
+
+    // Dynamic import keeps the Lenis chunk out of the initial JS bundle
+    // — the browser requests it only after hydration, off the critical
+    // path. The cancellation latch covers the StrictMode double-mount.
+    void import("lenis").then(({ default: Lenis }) => {
+      if (cancelled) return
+      const lenis = new Lenis({
+        duration: 1.2,
+        easing: (t: number) => 1 - Math.pow(1 - t, 4),
+      })
+
+      function raf(time: number) {
+        lenis.raf(time)
+        rafId = requestAnimationFrame(raf)
+      }
+      rafId = requestAnimationFrame(raf)
+      cleanup = () => {
+        lenis.destroy()
+        cancelAnimationFrame(rafId)
+      }
     })
 
-    let rafId: number
-    function raf(time: number) {
-      lenis.raf(time)
-      rafId = requestAnimationFrame(raf)
-    }
-    rafId = requestAnimationFrame(raf)
-
     return () => {
-      lenis.destroy()
-      cancelAnimationFrame(rafId)
+      cancelled = true
+      if (cleanup) cleanup()
     }
   }, [])
 


### PR DESCRIPTION
## Summary

Surgical first-load JS optimizations + the audit doc that explains the
constraints, fixes, and per-route budgets. No redesign, no new
dependencies, no removal of the cyber-pixel system.

### Fixes shipped

- **F.1 — Defer Lenis until after first paint.** `SmoothScroll` now
  loads `lenis` via a dynamic `import()` inside the effect, so the
  ~13 KB chunk is fetched only after hydration. Reduced-motion users
  get native scroll with no Lenis loaded at all.
- **F.2 — Lazy-load `CommandPalette` body.** Wrapped in
  `next/dynamic({ ssr: false })`, mounted on first open. The Cmd+K
  hotkey listener stays in the provider. cmdk + Radix Dialog + 14
  lucide icons + the `galleryItems` payload drop out of the
  every-route initial bundle.
- **F.3 — Lazy-load `GalleryLightbox`.** Wrapped in `next/dynamic`
  and only mounted when there's an open frame in the URL. Bundle
  fetches on first frame click or on deep-linked
  `/archive?frame=...`.
- **F.4 — `compiler.removeConsole` in production.** Strips dev logs
  from production client bundles, preserves `error`/`warn`.

### Audit doc

[docs/PERFORMANCE_AUDIT.md](docs/PERFORMANCE_AUDIT.md) covers:

- LCP element per route + the existing priority strategy
- INP / CLS risk inventory
- Heavy client component map
- Image and font posture (already healthy)
- Atmospheric-effect reduced-motion audit
- Advisory route budgets for every page
- Explicit list of things NOT changed
- Follow-ups for future PRs (bundle analyzer, CI budget guardrail,
  LazyMotion split)

## Build verification

Local production build hits the documented Windows
`readlink EISDIR` on `src/app/robots.ts` regardless of
`NEXT_DIST_DIR`. CI / Vercel build is the source of truth for
bundle sizes — re-measure on this PR's Vercel preview.

`npm run lint` and `npm run typecheck` both green locally.

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Cmd+K palette opens and works (loads chunk on first open)
- [ ] Click a gallery frame on /archive — lightbox opens (loads chunk
      on first click)
- [ ] Reload /archive with `?frame=<slug>` deep link — lightbox opens
      directly
- [ ] Toggle `prefers-reduced-motion` in DevTools — smooth scroll
      disabled, native scroll restored
- [ ] Run Lighthouse on the preview, compare against §11 budgets
- [ ] Confirm Speed Insights still receives data

🤖 Generated with [Claude Code](https://claude.com/claude-code)