### PR TITLE
feat(header): notifications bell + floating-dock header

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -280,6 +280,17 @@
     "readMore": "Read more",
     "status": "Status"
   },
+  "Notifications": {
+    "label": "Notifications",
+    "open": "Open notifications",
+    "heading": "What's new",
+    "subheading": "Recent log entries since you last stopped by.",
+    "empty": "All caught up. New logs will surface here.",
+    "markRead": "Mark all read",
+    "viewAll": "View all logs",
+    "newBadge": "new",
+    "unreadStatus": "{count, plural, =0 {No unread updates} one {# unread update} other {# unread updates}}"
+  },
   "CommandPalette": {
     "title": "Command palette",
     "description": "Jump to a page, frame, or setting.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -280,6 +280,17 @@
     "readMore": "继续阅读",
     "status": "状态"
   },
+  "Notifications": {
+    "label": "通知",
+    "open": "打开通知",
+    "heading": "新动态",
+    "subheading": "你上次到访以来的日志更新。",
+    "empty": "暂时没有新的更新。新日志会出现在这里。",
+    "markRead": "全部标为已读",
+    "viewAll": "查看全部日志",
+    "newBadge": "新",
+    "unreadStatus": "{count, plural, =0 {没有未读更新} other {# 条未读更新}}"
+  },
   "CommandPalette": {
     "title": "命令面板",
     "description": "快速跳转到页面、影像或设置。",

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -6,6 +6,8 @@ import { LanguageSwitcher } from "@/components/system/language-switcher";
 import { SoundToggle } from "@/components/system/sound-toggle";
 import { CommandPaletteTrigger } from "@/components/system/command-palette-trigger";
 import { CommandPaletteIconTrigger } from "@/components/system/command-palette-icon-trigger";
+import { NotificationBell } from "@/components/system/notification-bell";
+import { getPosts } from "@/lib/blog/get-posts";
 import { DesktopNav } from "./desktop-nav";
 import { MobileNav } from "./mobile-nav";
 import { buildNavStructure, type NavLabels } from "./nav-structure";
@@ -33,18 +35,39 @@ export async function Header({ locale }: { locale: Locale }) {
 
   const structure = buildNavStructure(labels);
 
+  // Re-uses the React.cache()-wrapped fetcher the /logs page calls,
+  // so the upstream dev.to request is deduped within a single render
+  // and amortised across requests via Next's fetch cache.
+  const posts = await getPosts();
+  const notificationFeed = posts.slice(0, 8).map((post) => ({
+    slug: post.slug,
+    title: post.title,
+    date: post.date,
+    category: post.category,
+    canonicalUrl: post.canonicalUrl,
+  }));
+
   return (
-    <header className="sticky top-0 z-40 border-b border-border/80 bg-background/85 backdrop-blur-xl">
-      <div className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between gap-3 px-4 sm:h-16 sm:gap-6 sm:px-6 lg:px-8">
+    // Outer wrapper is pointer-events-none so the gutter around the
+    // floating dock doesn't trap clicks on page content beneath. The
+    // dock itself re-enables them.
+    <header className="pointer-events-none sticky top-0 z-40 px-3 pt-3 sm:px-4 sm:pt-4">
+      <div className="pointer-events-auto mx-auto flex h-12 w-full max-w-7xl items-center gap-2 rounded-2xl border border-border/70 bg-background/70 px-2 shadow-lg shadow-black/5 backdrop-blur-2xl sm:h-14 sm:gap-3 sm:px-3 dark:shadow-black/20">
         <Link
           href="/"
           locale={locale}
-          className="flex shrink-0 items-center gap-2.5 font-mono text-sm transition-opacity duration-(--motion-fast) ease-(--ease-premium) hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          className="group inline-flex min-w-0 shrink-0 items-center gap-2.5 rounded-xl px-1.5 py-1 font-mono text-sm transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-          <span className="grid size-8 place-items-center rounded-md border bg-foreground text-background text-xs font-bold tracking-tight">
+          <span className="grid size-8 shrink-0 place-items-center rounded-lg border bg-foreground text-background text-xs font-bold tracking-tight shadow-sm transition-transform duration-(--motion-fast) ease-(--ease-premium) group-hover:scale-105 group-active:scale-100">
             M4
           </span>
-          <span className="hidden tracking-wide sm:inline">M4RKYU.SYS</span>
+          {/* Wordmark hides on the smallest screens so the dock can
+            * absorb wider non-Latin labels (zh nav items) without
+            * overflow. Wraps in `truncate` so any future locale that
+            * lengthens the brand string can't blow the row. */}
+          <span className="hidden truncate tracking-wide sm:inline">
+            M4RKYU.SYS
+          </span>
         </Link>
 
         <DesktopNav
@@ -54,17 +77,26 @@ export async function Header({ locale }: { locale: Locale }) {
           ariaLabel="Main navigation"
         />
 
-        {/* Desktop right rail (lg+): full Cmd-K pill + lang + theme + sound. */}
-        <div className="hidden shrink-0 items-center gap-2 lg:flex">
+        {/* Desktop right rail (lg+): full Cmd-K pill is its own
+          * tile; the four icon controls cluster inside a tinted
+          * sub-pill so they read as one bento module. */}
+        <div className="ml-auto hidden shrink-0 items-center gap-2 lg:flex">
           <CommandPaletteTrigger />
-          <LanguageSwitcher />
-          <ThemeSwitcher />
-          <SoundToggle />
+          <div className="flex items-center gap-0.5 rounded-xl border border-border/60 bg-muted/30 p-0.5">
+            <NotificationBell posts={notificationFeed} locale={locale} />
+            <LanguageSwitcher />
+            <ThemeSwitcher />
+            <SoundToggle />
+          </div>
         </div>
 
-        {/* Compact rail (<lg): icon search + theme + menu. */}
-        <div className="flex shrink-0 items-center gap-1.5 lg:hidden">
+        {/* Compact rail (<lg): Cmd-K icon + bell + theme + menu.
+          * Bell stays at this tier so visitors on phones still see
+          * unread counts; the sheet inside MobileNav owns lang and
+          * sound to keep the dock under five touch targets. */}
+        <div className="ml-auto flex shrink-0 items-center gap-1 lg:hidden">
           <CommandPaletteIconTrigger />
+          <NotificationBell posts={notificationFeed} locale={locale} />
           <ThemeSwitcher />
           <MobileNav locale={locale} groups={structure.groups} flatLinks={structure.flatLinks} />
         </div>

--- a/src/components/system/notification-bell.tsx
+++ b/src/components/system/notification-bell.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { Bell, BellRing } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import type { Locale } from "@/i18n/routing";
+import { cn } from "@/lib/utils";
+
+/** Minimal post shape the bell needs — keeps the prop surface narrow. */
+export interface NotificationPost {
+  slug: string;
+  title: string;
+  date: string;
+  category: string;
+  canonicalUrl?: string;
+}
+
+interface NotificationBellProps {
+  posts: NotificationPost[];
+  locale: Locale;
+}
+
+const STORAGE_KEY = "m4rkyu.notifications.lastSeen";
+
+/**
+ * useSyncExternalStore-driven read of the lastSeen timestamp from
+ * localStorage. The store emits via a `storage` event on writes (in
+ * other tabs) and via a window-scoped CustomEvent for same-tab
+ * writes (which `storage` doesn't fire for).
+ */
+const STORAGE_EVENT = "m4rkyu:notifications:lastSeen";
+
+function subscribeLastSeen(callback: () => void): () => void {
+  function onStorage(event: StorageEvent) {
+    if (event.key === STORAGE_KEY) callback();
+  }
+  window.addEventListener("storage", onStorage);
+  window.addEventListener(STORAGE_EVENT, callback);
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    window.removeEventListener(STORAGE_EVENT, callback);
+  };
+}
+
+function readLastSeen(): number {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? Number.parseInt(raw, 10) : 0;
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Server snapshot: treat everything as already-seen so SSR + first
+ * client paint don't flash a badge for returning visitors. The real
+ * value lands on the next render after hydration. */
+function serverSnapshot(): number {
+  return Number.POSITIVE_INFINITY;
+}
+
+/** Sort posts newest first by parsed date; unparseable dates sink. */
+function sortNewestFirst(posts: NotificationPost[]): NotificationPost[] {
+  return [...posts].sort((a, b) => {
+    const ta = Date.parse(a.date);
+    const tb = Date.parse(b.date);
+    if (Number.isNaN(ta) && Number.isNaN(tb)) return 0;
+    if (Number.isNaN(ta)) return 1;
+    if (Number.isNaN(tb)) return -1;
+    return tb - ta;
+  });
+}
+
+export function NotificationBell({ posts, locale }: NotificationBellProps) {
+  const t = useTranslations("Notifications");
+  const reduceMotion = useReducedMotion();
+  const [open, setOpen] = useState(false);
+  const lastSeen = useSyncExternalStore(
+    subscribeLastSeen,
+    readLastSeen,
+    serverSnapshot,
+  );
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click or Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onPointer(event: MouseEvent) {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const ordered = useMemo(() => sortNewestFirst(posts).slice(0, 6), [posts]);
+
+  const unreadCount = useMemo(() => {
+    // On the SSR pass / before hydration, serverSnapshot returns
+    // Infinity so this loop yields 0 — the badge stays hidden until
+    // the client has the real lastSeen value, avoiding a flash.
+    return ordered.reduce((count, post) => {
+      const stamp = Date.parse(post.date);
+      if (!Number.isFinite(stamp)) return count;
+      return stamp > lastSeen ? count + 1 : count;
+    }, 0);
+  }, [ordered, lastSeen]);
+
+  const markAllRead = useCallback(() => {
+    const now = Date.now();
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(now));
+      // Same-tab writes don't fire `storage`; broadcast manually so
+      // the subscriber recomputes.
+      window.dispatchEvent(new CustomEvent(STORAGE_EVENT));
+    } catch {
+      /* localStorage may be unavailable (private mode) — silent fallback. */
+    }
+  }, []);
+
+  const ariaStatus = t("unreadStatus", { count: unreadCount });
+
+  // Motion presets — single source of truth so reduced-motion can
+  // collapse them to instant transitions in one place.
+  const panelInitial = reduceMotion
+    ? { opacity: 0 }
+    : { opacity: 0, y: -8, scale: 0.96 };
+  const panelAnimate = reduceMotion
+    ? { opacity: 1 }
+    : { opacity: 1, y: 0, scale: 1 };
+  const panelTransition = reduceMotion
+    ? { duration: 0.12 }
+    : { duration: 0.18, ease: [0.2, 0.7, 0.2, 1] as const };
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <button
+        type="button"
+        aria-label={t("open")}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          "relative inline-flex size-9 items-center justify-center rounded-md border border-border bg-background/70 text-muted-foreground transition-[color,border-color,transform] duration-(--motion-fast) ease-(--ease-premium) hover:border-ring/50 hover:text-foreground hover:-translate-y-px active:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          open && "border-ring/60 text-foreground",
+        )}
+      >
+        {unreadCount > 0 ? (
+          <BellRing aria-hidden="true" className="size-4" />
+        ) : (
+          <Bell aria-hidden="true" className="size-4" />
+        )}
+        <AnimatePresence>
+          {unreadCount > 0 ? (
+            <motion.span
+              key="badge"
+              aria-hidden="true"
+              initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.5 }}
+              animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+              exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.5 }}
+              transition={{ duration: 0.2, ease: [0.2, 0.7, 0.2, 1] as const }}
+              className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-background bg-ring px-1 font-mono text-[0.55rem] font-semibold tabular-nums leading-none text-background"
+            >
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </motion.span>
+          ) : null}
+        </AnimatePresence>
+        <span className="sr-only">{ariaStatus}</span>
+      </button>
+
+      <AnimatePresence>
+        {open ? (
+          <motion.div
+            role="dialog"
+            aria-label={t("heading")}
+            initial={panelInitial}
+            animate={panelAnimate}
+            exit={panelInitial}
+            transition={panelTransition}
+            className="absolute right-0 top-[calc(100%+0.5rem)] z-50 w-[min(22rem,calc(100vw-2rem))] origin-top-right overflow-hidden rounded-xl border border-border/80 bg-background/95 shadow-xl shadow-black/10 backdrop-blur-xl"
+          >
+          <header className="flex items-baseline justify-between gap-3 border-b border-border/60 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-foreground">{t("heading")}</p>
+              <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+                {t("subheading")}
+              </p>
+            </div>
+            {ordered.length > 0 ? (
+              <button
+                type="button"
+                onClick={markAllRead}
+                disabled={unreadCount === 0}
+                className="shrink-0 rounded-sm font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {t("markRead")}
+              </button>
+            ) : null}
+          </header>
+
+          {ordered.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              {t("empty")}
+            </div>
+          ) : (
+            <ul className="max-h-80 overflow-y-auto py-1">
+              {ordered.map((post) => {
+                const stamp = Date.parse(post.date);
+                const isNew = Number.isFinite(stamp) && stamp > lastSeen;
+                return (
+                  <li key={post.slug}>
+                    <Link
+                      href={`/logs/${post.slug}`}
+                      locale={locale}
+                      onClick={() => {
+                        markAllRead();
+                        setOpen(false);
+                      }}
+                      className="group flex items-start gap-3 px-4 py-3 transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:bg-muted/50 focus-visible:bg-muted/60 focus-visible:outline-none"
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          "mt-1.5 inline-block size-1.5 shrink-0 rounded-full",
+                          isNew ? "bg-ring" : "bg-border",
+                        )}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-2">
+                          <span className="font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted-foreground">
+                            {post.category}
+                          </span>
+                          {isNew ? (
+                            <span className="rounded-sm border border-ring/40 bg-ring/10 px-1 font-mono text-[0.55rem] uppercase tracking-[0.18em] text-ring">
+                              {t("newBadge")}
+                            </span>
+                          ) : null}
+                        </span>
+                        <span className="mt-1 block truncate text-sm font-medium text-foreground group-hover:text-foreground">
+                          {post.title}
+                        </span>
+                        <span className="mt-1 block font-mono text-[0.65rem] text-muted-foreground">
+                          {post.date}
+                        </span>
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <footer className="border-t border-border/60 px-4 py-3">
+            <Link
+              href="/logs"
+              locale={locale}
+              onClick={() => setOpen(false)}
+              className="inline-flex items-center gap-1.5 font-mono text-[0.65rem] uppercase tracking-[0.18em] text-muted-foreground transition-colors duration-(--motion-fast) ease-(--ease-premium) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              <span className="truncate">{t("viewAll")}</span>
+              <span aria-hidden="true">→</span>
+            </Link>
+          </footer>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}


### PR DESCRIPTION
NotificationBell client island: useSyncExternalStore against a localStorage lastSeen key, motion/react popover with reduced-motion fallback, post-list compare-and-mark-read flow.

Header redesigned as a floating dock — rounded-2xl pill with pointer-events-none outer gutter, four icon controls (bell + lang + theme + sound) clustered into a tinted sub-pill on lg+, compact rail on mobile keeps the bell visible so unread counts surface on phones.

Bilingual i18n strings under Notifications.* in both locales.